### PR TITLE
Add Action Item Type entity and data

### DIFF
--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -18,8 +18,4 @@
         </PackageReference>
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Entities" />
-    </ItemGroup>
-
 </Project>

--- a/src/Domain/Entities/ActionItemTypes/ActionItemType.cs
+++ b/src/Domain/Entities/ActionItemTypes/ActionItemType.cs
@@ -1,8 +1,6 @@
-﻿using Sbeap.Domain.Identity;
+﻿namespace Sbeap.Domain.Entities.ActionItemTypes;
 
-namespace Sbeap.Domain.Entities.Offices;
-
-public class Office : AuditableEntity
+public class ActionItemType : AuditableEntity
 {
     // Constants
 
@@ -12,21 +10,19 @@ public class Office : AuditableEntity
     // Constructors
 
     [UsedImplicitly] // Used by ORM.
-    private Office() { }
+    private ActionItemType() { }
 
-    internal Office(Guid id, string name) : base(id) => SetName(name);
+    internal ActionItemType(Guid id, string name) : base(id) => SetName(name);
 
     // Properties
-    
+
     [StringLength(MaxNameLength, MinimumLength = MinNameLength)]
     public string Name { get; private set; } = string.Empty;
 
     public bool Active { get; set; } = true;
 
-    public List<ApplicationUser> StaffMembers { get; set; } = new();
-
     // Methods
-    
+
     internal void ChangeName(string name) => SetName(name);
 
     private void SetName(string name) =>

--- a/src/Domain/Entities/ActionItemTypes/ActionItemTypeManager.cs
+++ b/src/Domain/Entities/ActionItemTypes/ActionItemTypeManager.cs
@@ -1,0 +1,30 @@
+﻿using Sbeap.Domain.Exceptions;
+
+namespace Sbeap.Domain.Entities.ActionItemTypes;
+
+/// <inheritdoc />
+public class ActionItemTypeManager : IActionItemTypeManager
+{
+    private readonly IActionItemTypeRepository _repository;
+    public ActionItemTypeManager(IActionItemTypeRepository repository) => _repository = repository;
+
+    public async Task<ActionItemType> CreateAsync(string name, CancellationToken token = default)
+    {
+        await ThrowIfDuplicateName(name, ignoreId: null, token);
+        return new ActionItemType(Guid.NewGuid(), name);
+    }
+
+    public async Task ChangeNameAsync(ActionItemType actionItemType, string name, CancellationToken token = default)
+    {
+        await ThrowIfDuplicateName(name, actionItemType.Id, token);
+        actionItemType.ChangeName(name);
+    }
+
+    private async Task ThrowIfDuplicateName(string name, Guid? ignoreId, CancellationToken token)
+    {
+        // Validate the name is not a duplicate
+        var existing = await _repository.FindByNameAsync(name.Trim(), token);
+        if (existing is not null && (ignoreId is null || existing.Id != ignoreId))
+            throw new NameAlreadyExistsException(name);
+    }
+}

--- a/src/Domain/Entities/ActionItemTypes/IActionItemTypeManager.cs
+++ b/src/Domain/Entities/ActionItemTypes/IActionItemTypeManager.cs
@@ -1,0 +1,27 @@
+using Sbeap.Domain.Exceptions;
+
+namespace Sbeap.Domain.Entities.ActionItemTypes;
+
+/// <summary>
+/// A manager for managing Offices.
+/// </summary>
+public interface IActionItemTypeManager
+{
+    /// <summary>
+    /// Creates a new <see cref="ActionItemType"/>.
+    /// </summary>
+    /// <param name="name">The name of the Action Item Type to create.</param>
+    /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
+    /// <exception cref="NameAlreadyExistsException">Thrown if an Action Item Type already exists with the given name.</exception>
+    /// <returns>The Action Item Type that was created.</returns>
+    Task<ActionItemType> CreateAsync(string name, CancellationToken token = default);
+
+    /// <summary>
+    /// Changes the name of an <see cref="ActionItemType"/>.
+    /// </summary>
+    /// <param name="actionItemType">The Action Item Type to modify.</param>
+    /// <param name="name">The new name for the Action Item Type.</param>
+    /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
+    /// <exception cref="NameAlreadyExistsException">Thrown if an Action Item Type already exists with the given name.</exception>
+    Task ChangeNameAsync(ActionItemType actionItemType, string name, CancellationToken token = default);
+}

--- a/src/Domain/Entities/ActionItemTypes/IActionItemTypeRepository.cs
+++ b/src/Domain/Entities/ActionItemTypes/IActionItemTypeRepository.cs
@@ -1,0 +1,13 @@
+﻿namespace Sbeap.Domain.Entities.ActionItemTypes;
+
+public interface IActionItemTypeRepository : IRepository<ActionItemType, Guid>
+{
+    /// <summary>
+    /// Returns the <see cref="ActionItemType"/> with the given <paramref name="name"/>.
+    /// Returns null if the name does not exist.
+    /// </summary>
+    /// <param name="name">The name of the Action Item Type.</param>
+    /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
+    /// <returns>An Action Item Type entity.</returns>
+    Task<ActionItemType?> FindByNameAsync(string name, CancellationToken token = default);
+}

--- a/src/Domain/GlobalUsings.cs
+++ b/src/Domain/GlobalUsings.cs
@@ -1,5 +1,6 @@
 ﻿global using GaEpd.AppLibrary.Domain.Entities;
 global using GaEpd.AppLibrary.Domain.Repositories;
 global using GaEpd.AppLibrary.GuardClauses;
+global using JetBrains.Annotations;
 global using System.ComponentModel.DataAnnotations;
 global using System.ComponentModel.DataAnnotations.Schema;

--- a/src/Domain/ValueObjects/Address.cs
+++ b/src/Domain/ValueObjects/Address.cs
@@ -1,5 +1,4 @@
 ﻿using GaEpd.AppLibrary.Domain.ValueObjects;
-using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 
 namespace Sbeap.Domain.ValueObjects;

--- a/src/TestData/ActionItemTypeData.cs
+++ b/src/TestData/ActionItemTypeData.cs
@@ -1,0 +1,38 @@
+﻿using Sbeap.Domain.Entities.ActionItemTypes;
+
+namespace Sbeap.TestData;
+
+internal static class ActionItemTypeData
+{
+    private static IEnumerable<ActionItemType> ActionItemTypeSeedItems => new List<ActionItemType>
+    {
+        new(new Guid("20000000-0000-0000-0000-000000000001"), "CAP meetings") { Active = false },
+        new(new Guid("20000000-0000-0000-0000-000000000002"), "Compliance Assistance") { Active = false },
+        new(new Guid("20000000-0000-0000-0000-000000000003"), "Drafting Small Bus Impact Memos") { Active = false },
+        new(new Guid("20000000-0000-0000-0000-000000000004"), "Email Sent/Received"),
+        new(new Guid("20000000-0000-0000-0000-000000000005"), "Mass Mailing") { Active = false },
+        new(new Guid("20000000-0000-0000-0000-000000000006"), "Meeting/Conferences Attended") { Active = false },
+        new(new Guid("20000000-0000-0000-0000-000000000007"), "Other"),
+        new(new Guid("20000000-0000-0000-0000-000000000008"), "Permit Assistance"),
+        new(new Guid("20000000-0000-0000-0000-000000000009"), "Phone Call Made/Received"),
+        new(new Guid("20000000-0000-0000-0000-000000000010"), "Publication/Document Sent") { Active = false },
+        new(new Guid("20000000-0000-0000-0000-000000000011"), "Site Visit"),
+        new(new Guid("20000000-0000-0000-0000-000000000012"), "Stakeholder meetings") { Active = false },
+        new(new Guid("20000000-0000-0000-0000-000000000013"), "Workshops/Training Courses Conducted")
+            { Active = false },
+    };
+
+    private static IEnumerable<ActionItemType>? _actionItemTypes;
+
+    public static IEnumerable<ActionItemType> GetActionItemTypes
+    {
+        get
+        {
+            if (_actionItemTypes is not null) return _actionItemTypes;
+            _actionItemTypes = ActionItemTypeSeedItems;
+            return _actionItemTypes;
+        }
+    }
+
+    public static void ClearData() => _actionItemTypes = null;
+}


### PR DESCRIPTION
This PR adds the Action Item Type entity model as well as sample data. The data likely represents what the final migrated data will be based on earlier discussions with the program: https://github.com/gaepdit/sbeap/discussions/9.

closes #60 