### PR TITLE
Use records for DTOs instead of classes

### DIFF
--- a/src/AppServices/Cases/Dto/ActionItemCreateDto.cs
+++ b/src/AppServices/Cases/Dto/ActionItemCreateDto.cs
@@ -2,11 +2,10 @@
 
 namespace Sbeap.AppServices.Cases.Dto;
 
-public class ActionItemCreateDto
-{
-    public Guid CaseworkId { get; init; }
-
-    public ActionItemType ActionItemType { get; private init; } = default!;
-    public DateOnly ActionDate { get; init; }
-    public string Notes { get; init; } = string.Empty;
-}
+public record ActionItemCreateDto
+(
+    Guid CaseworkId,
+    ActionItemType ActionItemType,
+    DateOnly ActionDate,
+    string Notes
+);

--- a/src/AppServices/Cases/Dto/ActionItemUpdateDto.cs
+++ b/src/AppServices/Cases/Dto/ActionItemUpdateDto.cs
@@ -2,11 +2,9 @@
 
 namespace Sbeap.AppServices.Cases.Dto;
 
-public class ActionItemUpdateDto
-{
-    public Guid Id { get; init; }
-
-    public ActionItemType ActionItemType { get; private init; } = default!;
-    public DateOnly ActionDate { get; init; }
-    public string Notes { get; init; } = string.Empty;
-}
+public record ActionItemUpdateDto(
+    Guid Id,
+    ActionItemType ActionItemType,
+    DateOnly ActionDate,
+    string Notes
+);

--- a/src/AppServices/Cases/Dto/ActionItemViewDto.cs
+++ b/src/AppServices/Cases/Dto/ActionItemViewDto.cs
@@ -2,12 +2,12 @@
 
 namespace Sbeap.AppServices.Cases.Dto;
 
-public class ActionItemViewDto
-{
-    public Guid Id { get; init; }
-    public string ActionItemTypeName { get; private init; } = default!;
-    public DateOnly ActionDate { get; init; }
-    public string Notes { get; init; } = string.Empty;
-    public StaffViewDto EnteredBy { get; init; } = default!;
-    public bool IsDeleted { get; init; }
-}
+public record ActionItemViewDto
+(
+    Guid Id,
+    string ActionItemTypeName,
+    DateOnly ActionDate,
+    string Notes,
+    StaffViewDto EnteredBy,
+    bool IsDeleted
+);

--- a/src/AppServices/Cases/Dto/CaseworkCreateDto.cs
+++ b/src/AppServices/Cases/Dto/CaseworkCreateDto.cs
@@ -1,9 +1,8 @@
 ﻿namespace Sbeap.AppServices.Cases.Dto;
 
-public class CaseworkCreateDto
-{
-    public Guid CustomerId { get; init; }
-
-    public DateOnly CaseOpenedDate { get; init; }
-    public string Description { get; init; } = string.Empty;
-}
+public record CaseworkCreateDto
+(
+    Guid CustomerId,
+    DateOnly CaseOpenedDate,
+    string Description
+);

--- a/src/AppServices/Cases/Dto/CaseworkSearchDto.cs
+++ b/src/AppServices/Cases/Dto/CaseworkSearchDto.cs
@@ -5,61 +5,48 @@ using System.Text.Json.Serialization;
 namespace Sbeap.AppServices.Cases.Dto;
 
 public record CaseworkSearchDto
-{
+(
     // Sorting
-    public CaseworkSortBy Sort { get; init; } = CaseworkSortBy.CustomerAsc;
+    CaseworkSortBy Sort,
 
     // Status
-
-    [Display(Name = "Case Status")]
-    public CaseStatus? Status { get; init; }
-
-    [Display(Name = "Deletion Status")]
-    public CaseDeletedStatus? DeletedStatus { get; init; }
+    [Display(Name = "Case Status")] CaseStatus? Status,
+    [Display(Name = "Deletion Status")] CaseDeletedStatus? DeletedStatus,
 
     // Dates
-
     [Display(Name = "From")]
     [DataType(DataType.Date)]
-    [DisplayFormat(DataFormatString = "{0:O}", ApplyFormatInEditMode = true)]
-    public DateOnly? OpenedFrom { get; init; }
-
+    // [DisplayFormat(DataFormatString = "{0:O}", ApplyFormatInEditMode = true)]
+    DateOnly? OpenedFrom,
     [Display(Name = "Through")]
     [DataType(DataType.Date)]
-    [DisplayFormat(DataFormatString = "{0:O}", ApplyFormatInEditMode = true)]
-    public DateOnly? OpenedTo { get; init; }
-
+    // [DisplayFormat(DataFormatString = "{0:O}", ApplyFormatInEditMode = true)]
+    DateOnly? OpenedTo,
     [Display(Name = "From")]
     [DataType(DataType.Date)]
-    [DisplayFormat(DataFormatString = "{0:O}", ApplyFormatInEditMode = true)]
-    public DateOnly? ClosedFrom { get; init; }
-
+    // [DisplayFormat(DataFormatString = "{0:O}", ApplyFormatInEditMode = true)]
+    DateOnly? ClosedFrom,
     [Display(Name = "Through")]
     [DataType(DataType.Date)]
-    [DisplayFormat(DataFormatString = "{0:O}", ApplyFormatInEditMode = true)]
-    public DateOnly? ClosedTo { get; init; }
+    // [DisplayFormat(DataFormatString = "{0:O}", ApplyFormatInEditMode = true)]
+    DateOnly? ClosedTo,
 
     // Fields
-
-    public string? CustomerName { get; init; } 
-
-    public string? Description { get; set; }
-
-    [Display(Name = "Referred to")]
-    public Guid? Agency { get; init; }
+    string? CustomerName,
+    string? Description,
+    [Display(Name = "Referred to")] Guid? Agency,
 
     // Referral
-
     [Display(Name = "From")]
     [DataType(DataType.Date)]
-    [DisplayFormat(DataFormatString = "{0:O}", ApplyFormatInEditMode = true)]
-    public DateOnly? ReferredFrom { get; init; }
-
+    // [DisplayFormat(DataFormatString = "{0:O}", ApplyFormatInEditMode = true)]
+    DateOnly? ReferredFrom,
     [Display(Name = "Through")]
     [DataType(DataType.Date)]
-    [DisplayFormat(DataFormatString = "{0:O}", ApplyFormatInEditMode = true)]
-    public DateOnly? ReferredTo { get; init; }
-
+    // [DisplayFormat(DataFormatString = "{0:O}", ApplyFormatInEditMode = true)]
+    DateOnly? ReferredTo
+)
+{
     // UI Routing
     public IDictionary<string, string?> AsRouteValues() => new Dictionary<string, string?>
     {
@@ -77,10 +64,10 @@ public record CaseworkSearchDto
         { nameof(ReferredTo), ReferredTo?.ToString("d") },
     };
 
-    public void TrimAll()
+    public CaseworkSearchDto TrimAll() => this with
     {
-        Description = Description?.Trim();
-    }
+        Description = Description?.Trim(),
+    };
 }
 
 // Search enums

--- a/src/AppServices/Cases/Dto/CaseworkSearchResultDto.cs
+++ b/src/AppServices/Cases/Dto/CaseworkSearchResultDto.cs
@@ -1,17 +1,12 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿namespace Sbeap.AppServices.Cases.Dto;
 
-namespace Sbeap.AppServices.Cases.Dto;
-
-public class CaseworkSearchResultDto
-{
-    public Guid Id { get; init; }
-    public string CustomerName { get; init; } = string.Empty;
-    public DateOnly CaseOpenedDate { get; init; }
-    public DateOnly? CaseClosedDate { get; init; }
-    public string Description { get; init; } = string.Empty;
-
-    [UIHint("BoolClosed")]
-    public bool IsClosed { get; init; }
-
-    public bool IsDeleted { get; init; }
-}
+public record CaseworkSearchResultDto
+(
+    Guid Id,
+    string CustomerName,
+    DateOnly CaseOpenedDate,
+    DateOnly? CaseClosedDate,
+    string Description,
+    bool IsClosed,
+    bool IsDeleted
+);

--- a/src/AppServices/Cases/Dto/CaseworkUpdateDto.cs
+++ b/src/AppServices/Cases/Dto/CaseworkUpdateDto.cs
@@ -1,14 +1,13 @@
 ﻿namespace Sbeap.AppServices.Cases.Dto;
 
-public class CaseworkUpdateDto
-{
-    public Guid Id { get; init; }
-
-    public DateOnly CaseOpenedDate { get; init; }
-    public string Description { get; init; } = string.Empty;
-    public DateOnly? CaseClosedDate { get; init; }
-    public string? CaseClosureNotes { get; init; }
-    public Guid? ReferralAgencyId { get; init; }
-    public DateOnly? ReferralDate { get; init; }
-    public string? ReferralNotes { get; init; }
-}
+public record CaseworkUpdateDto
+(
+    Guid Id,
+    DateOnly CaseOpenedDate,
+    string Description,
+    DateOnly? CaseClosedDate,
+    string? CaseClosureNotes,
+    Guid? ReferralAgencyId,
+    DateOnly? ReferralDate,
+    string? ReferralNotes
+);

--- a/src/AppServices/Cases/Dto/CaseworkViewDto.cs
+++ b/src/AppServices/Cases/Dto/CaseworkViewDto.cs
@@ -2,18 +2,18 @@
 
 namespace Sbeap.AppServices.Cases.Dto;
 
-public class CaseworkViewDto
-{
-    public Guid Id { get; init; }
-    public CustomerSearchResultDto Customer { get; init; } = default!;
-    public string Description { get; init; } = string.Empty;
-    public DateOnly CaseOpenedDate { get; init; }
-    public DateOnly? CaseClosedDate { get; init; }
-    public bool IsClosed { get; init; }
-    public string? CaseClosureNotes { get; init; }
-    public string? ReferralAgencyName { get; init; }
-    public DateOnly? ReferralDate { get; init; }
-    public string? ReferralNotes { get; init; }
-    public ICollection<ActionItemViewDto> ActionItems { get; init; } = new List<ActionItemViewDto>();
-    public bool IsDeleted { get; init; }
-}
+public record CaseworkViewDto
+(
+    Guid Id,
+    CustomerSearchResultDto Customer,
+    string Description,
+    DateOnly CaseOpenedDate,
+    DateOnly? CaseClosedDate,
+    bool IsClosed,
+    string? CaseClosureNotes,
+    string? ReferralAgencyName,
+    DateOnly? ReferralDate,
+    string? ReferralNotes,
+    ICollection<ActionItemViewDto> ActionItems,
+    bool IsDeleted
+);

--- a/src/AppServices/Customers/Dto/ContactCreateDto.cs
+++ b/src/AppServices/Customers/Dto/ContactCreateDto.cs
@@ -1,48 +1,31 @@
-﻿using GaEpd.AppLibrary.Domain.ValueObjects;
-using Sbeap.Domain.ValueObjects;
+﻿using Sbeap.Domain.ValueObjects;
 using System.ComponentModel.DataAnnotations;
 
 namespace Sbeap.AppServices.Customers.Dto;
 
-public record ContactCreateDto : ValueObject
-{
-    public string? Honorific { get; init; }
-
-    [Display(Name = "First name")]
-    public string? GivenName { get; init; }
-
-    [Display(Name = "Last name")]
-    public string? FamilyName { get; init; }
-
-    public string? Title { get; init; }
-
+public record ContactCreateDto
+(
+    string? Honorific,
+    [Display(Name = "First name")] string? GivenName,
+    [Display(Name = "Last name")] string? FamilyName,
+    string? Title,
     [EmailAddress]
     [StringLength(150)]
     [DataType(DataType.EmailAddress)]
     [Display(Name = "Email address")]
-    public string? Email { get; init; }
-
-    public string? Notes { get; init; }
-    public IncompleteAddress Address { get; init; } = default!;
-
-    [Display(Name = "Phone number")]
-    public PhoneNumber PhoneNumber { get; init; } = default!;
-
-    public static ContactCreateDto EmptyContact => new()
-    {
-        Address = IncompleteAddress.EmptyAddress,
-        PhoneNumber = PhoneNumber.EmptyPhoneNumber,
-    };
-
-    protected override IEnumerable<object> GetEqualityComponents()
-    {
-        yield return Honorific ?? string.Empty;
-        yield return GivenName ?? string.Empty;
-        yield return FamilyName ?? string.Empty;
-        yield return Title ?? string.Empty;
-        yield return Email ?? string.Empty;
-        yield return Notes ?? string.Empty;
-        yield return Address;
-        yield return PhoneNumber;
-    }
+    string? Email,
+    string? Notes,
+    IncompleteAddress Address,
+    [Display(Name = "Phone number")] PhoneNumber PhoneNumber
+)
+{
+    public bool IsEmpty() =>
+        string.IsNullOrEmpty(Honorific) &&
+        string.IsNullOrEmpty(GivenName) &&
+        string.IsNullOrEmpty(FamilyName) &&
+        string.IsNullOrEmpty(Title) &&
+        string.IsNullOrEmpty(Email) &&
+        string.IsNullOrEmpty(Notes) &&
+        Address == IncompleteAddress.EmptyAddress &&
+        PhoneNumber == PhoneNumber.EmptyPhoneNumber;
 }

--- a/src/AppServices/Customers/Dto/ContactUpdateDto.cs
+++ b/src/AppServices/Customers/Dto/ContactUpdateDto.cs
@@ -3,26 +3,18 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Sbeap.AppServices.Customers.Dto;
 
-public class ContactUpdateDto
-{
-    public Guid Id { get; init; }
-
-    public string? Honorific { get; init; } = string.Empty;
-
-    [Display(Name = "First name")]
-    public string? GivenName { get; init; } = string.Empty;
-
-    [Display(Name = "Last name")]
-    public string? FamilyName { get; init; } = string.Empty;
-
-    public string? Title { get; init; } = string.Empty;
-
+public record ContactUpdateDto
+(
+    Guid Id,
+    string? Honorific,
+    [Display(Name = "First name")] string? GivenName,
+    [Display(Name = "Last name")] string? FamilyName,
+    string? Title,
     [EmailAddress]
     [StringLength(150)]
     [DataType(DataType.EmailAddress)]
     [Display(Name = "Email address")]
-    public string? Email { get; init; } = string.Empty;
-
-    public string? Notes { get; init; } = string.Empty;
-    public IncompleteAddress Address { get; init; } = default!;
-}
+    string? Email,
+    string? Notes,
+    IncompleteAddress Address
+);

--- a/src/AppServices/Customers/Dto/ContactViewDto.cs
+++ b/src/AppServices/Customers/Dto/ContactViewDto.cs
@@ -4,31 +4,27 @@ using System.Text.Json.Serialization;
 
 namespace Sbeap.AppServices.Customers.Dto;
 
-public class ContactViewDto
-{
-    public Guid Id { get; init; }
-    public string Honorific { get; init; } = string.Empty;
-    public string GivenName { get; init; } = string.Empty;
-    public string FamilyName { get; init; } = string.Empty;
-    public string Title { get; init; } = string.Empty;
-
+public record ContactViewDto
+(
+    Guid Id,
+    string Honorific,
+    string GivenName,
+    string FamilyName,
+    string Title,
     [EmailAddress]
     [StringLength(150)]
     [DataType(DataType.EmailAddress)]
-    public string Email { get; init; } = string.Empty;
-
-    public string Notes { get; init; } = string.Empty;
-    public IncompleteAddress Address { get; init; } = default!;
-
+    string Email,
+    string Notes,
+    IncompleteAddress Address,
+    bool IsDeleted,
+    DateTimeOffset? EnteredOn
+)
+{
     [Display(Name = "Phone Numbers")]
     public ICollection<PhoneNumber> PhoneNumbers { get; } = new List<PhoneNumber>();
 
-    public bool IsDeleted { get; init; }
-
-    public DateTimeOffset? EnteredOn { get; init; }
-
     // Read-only properties
-
     [JsonIgnore]
     public string Name =>
         string.Join(" ", new[] { Honorific, GivenName, FamilyName }.Where(s => !string.IsNullOrEmpty(s)));

--- a/src/AppServices/Customers/Dto/CustomerCreateDto.cs
+++ b/src/AppServices/Customers/Dto/CustomerCreateDto.cs
@@ -3,19 +3,13 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Sbeap.AppServices.Customers.Dto;
 
-public class CustomerCreateDto
-{
-    [Required]
-    public string Name { get; init; } = string.Empty;
-
-    public string? Description { get; init; }
-    public string? County { get; init; }
-    
-    [MaxLength(2000)] // https://stackoverflow.com/q/417142/212978
-    public string? Website { get; set; } = string.Empty;
-
-    public IncompleteAddress Location { get; init; } = default!;
-    public IncompleteAddress MailingAddress { get; init; } = default!;
-
-    public ContactCreateDto Contact { get; init; } = default!;
-}
+public record CustomerCreateDto
+(
+    [Required] string Name,
+    string? Description,
+    string? County,
+    [MaxLength(2000)] string? Website, // https://stackoverflow.com/q/417142/212978
+    IncompleteAddress Location,
+    IncompleteAddress MailingAddress,
+    ContactCreateDto Contact
+);

--- a/src/AppServices/Customers/Dto/CustomerSearchDto.cs
+++ b/src/AppServices/Customers/Dto/CustomerSearchDto.cs
@@ -5,16 +5,14 @@ using System.Text.Json.Serialization;
 namespace Sbeap.AppServices.Customers.Dto;
 
 public record CustomerSearchDto
+(
+    CustomerSortBy Sort,
+    string? Name,
+    string? Description,
+    string? County,
+    [Display(Name = "Deletion Status")] CustomerDeletedStatus? DeletedStatus
+)
 {
-    public CustomerSortBy Sort { get; init; } = CustomerSortBy.NameAsc;
-
-    public string? Name { get; set; }
-    public string? Description { get; set; }
-    public string? County { get; set; }
-
-    [Display(Name = "Deletion Status")]
-    public CustomerDeletedStatus? DeletedStatus { get; init; }
-
     // UI Routing
     public IDictionary<string, string?> AsRouteValues() => new Dictionary<string, string?>
     {
@@ -25,12 +23,12 @@ public record CustomerSearchDto
         { nameof(DeletedStatus), DeletedStatus?.ToString() },
     };
 
-    public void TrimAll()
+    public CustomerSearchDto TrimAll() => this with
     {
-        Name = Name?.Trim();
-        Description = Description?.Trim();
-        County = County?.Trim();
-    }
+        Name = Name?.Trim(),
+        Description = Description?.Trim(),
+        County = County?.Trim(),
+    };
 }
 
 // Search enums

--- a/src/AppServices/Customers/Dto/CustomerSearchResultDto.cs
+++ b/src/AppServices/Customers/Dto/CustomerSearchResultDto.cs
@@ -1,11 +1,10 @@
-﻿namespace Sbeap.AppServices.Customers.Dto;
+namespace Sbeap.AppServices.Customers.Dto;
 
-public class CustomerSearchResultDto
-{
-    public Guid Id { get; init; }
-    public string Name { get; init; } = string.Empty;
-    // public int NumberOfCases { get; init; }
-    public string Description { get; init; } = string.Empty;
-    public string? County { get; init; }
-    public bool IsDeleted { get; init; }
-}
+public record CustomerSearchResultDto
+(
+    Guid Id,
+    string Name,
+    string Description,
+    string? County,
+    bool IsDeleted
+);

--- a/src/AppServices/Customers/Dto/CustomerUpdateDto.cs
+++ b/src/AppServices/Customers/Dto/CustomerUpdateDto.cs
@@ -2,13 +2,12 @@
 
 namespace Sbeap.AppServices.Customers.Dto;
 
-public class CustomerUpdateDto
-{
-    public Guid Id { get; init; }
-
-    public string Name { get; init; } = string.Empty;
-    public string Description { get; init; } = string.Empty;
-    public string? County { get; init; }
-    public IncompleteAddress Location { get; init; } = default!;
-    public IncompleteAddress MailingAddress { get; init; } = default!;
-}
+public record CustomerUpdateDto
+(
+    Guid Id,
+    string Name,
+    string Description,
+    string? County,
+    IncompleteAddress Location,
+    IncompleteAddress MailingAddress
+);

--- a/src/AppServices/Customers/Dto/CustomerViewDto.cs
+++ b/src/AppServices/Customers/Dto/CustomerViewDto.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Sbeap.AppServices.Customers.Dto;
 
-public class CustomerViewDto
+public record CustomerViewDto
 {
     public Guid Id { get; init; }
     public string Name { get; init; } = string.Empty;
@@ -28,7 +28,7 @@ public class CustomerViewDto
     public bool IsDeleted { get; init; }
 
     [Display(Name = "Deleted By")]
-    public StaffViewDto? DeletedBy { get; set; }
+    public StaffViewDto? DeletedBy { get; init; }
 
     [Display(Name = "Date Deleted")]
     public DateTimeOffset? DeletedAt { get; init; }

--- a/src/AppServices/Customers/Validators/CustomerCreateValidator.cs
+++ b/src/AppServices/Customers/Validators/CustomerCreateValidator.cs
@@ -20,6 +20,6 @@ public class CustomerCreateValidator : AbstractValidator<CustomerCreateDto>
         // Embedded Contact
         RuleFor(e => e.Contact)
             .SetValidator(new ContactCreateValidator())
-            .When(e => e.Contact != ContactCreateDto.EmptyContact);
+            .When(e => !e.Contact.IsEmpty());
     }
 }

--- a/src/AppServices/DtoBase/SimpleNamedEntityDto.cs
+++ b/src/AppServices/DtoBase/SimpleNamedEntityDto.cs
@@ -8,29 +8,25 @@ public interface IDtoHasNameProperty
     string Name { get; }
 }
 
-public abstract class SimpleNamedEntityViewDto : IDtoHasNameProperty
-{
-    public Guid Id { get; init; }
-    public string Name { get; init; } = string.Empty;
+public abstract record SimpleNamedEntityViewDto
+(
+    Guid Id,
+    string Name,
+    bool Active
+) : IDtoHasNameProperty;
 
-    [UIHint("BoolActive")]
-    public bool Active { get; init; }
-}
-
-public abstract class SimpleNamedEntityCreateDto
-{
+public abstract record SimpleNamedEntityCreateDto
+(
     [Required(AllowEmptyStrings = false)]
     [StringLength(SimpleNamedEntity.MaxNameLength, MinimumLength = SimpleNamedEntity.MinNameLength)]
-    public string Name { get; init; } = string.Empty;
-}
+    string Name
+);
 
-public abstract class SimpleNamedEntityUpdateDto
-{
-    public Guid Id { get; init; }
-
+public abstract record SimpleNamedEntityUpdateDto
+(
+    Guid Id,
     [Required(AllowEmptyStrings = false)]
     [StringLength(SimpleNamedEntity.MaxNameLength, MinimumLength = SimpleNamedEntity.MinNameLength)]
-    public string Name { get; init; } = string.Empty;
-
-    public bool Active { get; init; }
-}
+    string Name,
+    bool Active
+);

--- a/src/AppServices/Offices/OfficeDtos.cs
+++ b/src/AppServices/Offices/OfficeDtos.cs
@@ -2,8 +2,8 @@
 
 namespace Sbeap.AppServices.Offices;
 
-public class OfficeViewDto : SimpleNamedEntityViewDto { }
+public record OfficeViewDto(Guid Id, string Name, bool Active) : SimpleNamedEntityViewDto(Id, Name, Active);
 
-public class OfficeCreateDto : SimpleNamedEntityCreateDto { }
+public record OfficeCreateDto(string Name) : SimpleNamedEntityCreateDto(Name);
 
-public class OfficeUpdateDto : SimpleNamedEntityUpdateDto { }
+public record OfficeUpdateDto(Guid Id, string Name, bool Active) : SimpleNamedEntityUpdateDto(Id, Name, Active);

--- a/src/AppServices/Staff/Dto/StaffSearchDto.cs
+++ b/src/AppServices/Staff/Dto/StaffSearchDto.cs
@@ -5,20 +5,18 @@ using System.Text.Json.Serialization;
 namespace Sbeap.AppServices.Staff.Dto;
 
 public record StaffSearchDto
-{
+(
     // Sorting
-    public SortBy Sort { get; init; } = SortBy.NameAsc;
+    SortBy Sort,
 
     // Fields
-    public string? Name { get; set; }
-
-    [EmailAddress]
-    public string? Email { get; set; }
-
-    public string? Role { get; init; }
-    public Guid? Office { get; init; }
-    public SearchStaffStatus? Status { get; init; } = SearchStaffStatus.Active;
-
+    string? Name,
+    [EmailAddress] string? Email,
+    string? Role,
+    Guid? Office,
+    SearchStaffStatus? Status
+)
+{
     // UI Routing
     public IDictionary<string, string?> AsRouteValues() => new Dictionary<string, string?>
     {
@@ -30,11 +28,11 @@ public record StaffSearchDto
         { nameof(Status), Status?.ToString() },
     };
 
-    public void TrimAll()
+    public StaffSearchDto TrimAll() => this with
     {
-        Name = Name?.Trim();
-        Email = Email?.Trim();
-    }
+        Name = Name?.Trim(),
+        Email = Email?.Trim(),
+    };
 }
 
 // Search enums

--- a/src/AppServices/Staff/Dto/StaffSearchResultDto.cs
+++ b/src/AppServices/Staff/Dto/StaffSearchResultDto.cs
@@ -1,28 +1,17 @@
-﻿using JetBrains.Annotations;
-using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace Sbeap.AppServices.Staff.Dto;
 
-public class StaffSearchResultDto
+public record StaffSearchResultDto
+(
+    string Id,
+    string GivenName,
+    string FamilyName,
+    string Email,
+    string? OfficeName,
+    bool Active
+)
 {
-    public string Id { get; init; } = string.Empty;
-
-    [UsedImplicitly]
-    public string GivenName { get; init; } = string.Empty;
-
-    [UsedImplicitly]
-    public string FamilyName { get; init; } = string.Empty;
-
-    public string Email { get; init; } = string.Empty;
-
-    public string? OfficeName { get; init; }
-
-    [UIHint("BoolActive")]
-    public bool Active { get; init; }
-
-    // Read-only properties
-
     [JsonIgnore]
     public string SortableFullName =>
         string.Join(", ", new[] { FamilyName, GivenName }.Where(s => !string.IsNullOrEmpty(s)));

--- a/src/AppServices/Staff/Dto/StaffUpdateDto.cs
+++ b/src/AppServices/Staff/Dto/StaffUpdateDto.cs
@@ -3,18 +3,12 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Sbeap.AppServices.Staff.Dto;
 
-public class StaffUpdateDto
-{
-    public string Id { get; init; } = string.Empty;
-
+public record StaffUpdateDto
+(
+    string Id,
     [StringLength(ApplicationUser.MaxPhoneLength,
         ErrorMessage = "The Phone Number must not be longer than {1} characters.")]
-    public string? Phone { get; init; }
-
-    [Required]
-    [Display(Name = "Office")]
-    public Guid? OfficeId { get; init; }
-
-    [Required]
-    public bool Active { get; init; }
-}
+    string? Phone,
+    [Required] [Display(Name = "Office")] Guid? OfficeId,
+    [Required] bool Active
+);

--- a/src/AppServices/Staff/Dto/StaffViewDto.cs
+++ b/src/AppServices/Staff/Dto/StaffViewDto.cs
@@ -5,21 +5,18 @@ using System.Text.Json.Serialization;
 
 namespace Sbeap.AppServices.Staff.Dto;
 
-public class StaffViewDto : IDtoHasNameProperty
-{
-    public string Id { get; init; } = string.Empty;
-    public string GivenName { get; init; } = string.Empty;
-    public string FamilyName { get; init; } = string.Empty;
-
+public record StaffViewDto
+(
+    string Id,
+    string GivenName,
+    string FamilyName,
     [Display(Name = "Email cannot be changed")]
-    public string? Email { get; init; }
-
-    public string? Phone { get; init; }
-    public OfficeViewDto? Office { get; init; }
-
-    [UIHint("BoolActive")]
-    public bool Active { get; init; }
-
+    string? Email,
+    string? Phone,
+    OfficeViewDto? Office,
+    bool Active
+) : IDtoHasNameProperty
+{
     [JsonIgnore]
     public string Name =>
         string.Join(" ", new[] { GivenName, FamilyName }.Where(s => !string.IsNullOrEmpty(s)));
@@ -28,6 +25,5 @@ public class StaffViewDto : IDtoHasNameProperty
     public string SortableFullName =>
         string.Join(", ", new[] { FamilyName, GivenName }.Where(s => !string.IsNullOrEmpty(s)));
 
-    public StaffUpdateDto AsUpdateDto() =>
-        new() { Id = Id, Phone = Phone, OfficeId = Office?.Id, Active = Active };
+    public StaffUpdateDto AsUpdateDto() => new(Id, Phone, Office?.Id, Active);
 }

--- a/src/Domain/ValueObjects/IncompleteAddress.cs
+++ b/src/Domain/ValueObjects/IncompleteAddress.cs
@@ -10,15 +10,15 @@ public record IncompleteAddress : ValueObject
     public string? Street { get; [UsedImplicitly] init; }
 
     [Display(Name = "Apt / Suite / Other")]
-    public string? Street2 { get; [UsedImplicitly] set; }
+    public string? Street2 { get; [UsedImplicitly] init; }
 
-    public string? City { get; [UsedImplicitly] set; }
+    public string? City { get; [UsedImplicitly] init; }
 
-    public string? State { get; [UsedImplicitly] set; }
+    public string? State { get; [UsedImplicitly] init; }
 
     [DataType(DataType.PostalCode)]
     [Display(Name = "Postal Code")]
-    public string? PostalCode { get; [UsedImplicitly] set; }
+    public string? PostalCode { get; [UsedImplicitly] init; }
 
     protected override IEnumerable<object> GetEqualityComponents()
     {

--- a/src/WebApp/Pages/Account/ExternalLogin.cshtml.cs
+++ b/src/WebApp/Pages/Account/ExternalLogin.cshtml.cs
@@ -72,11 +72,14 @@ public class ExternalLoginModel : PageModel
             ApplicationSettings.DevSettings.LocalUserIsAdmin);
         if (!ApplicationSettings.DevSettings.LocalUserIsAuthenticated) return Forbid();
 
-        var search = new StaffSearchDto { Name = "Limited" };
+        StaffSearchDto search;
+
         if (ApplicationSettings.DevSettings.LocalUserIsStaff)
-            search.Name = "General";
+            search = new StaffSearchDto(SortBy.NameAsc, "General", null, null, null, null);
         else if (ApplicationSettings.DevSettings.LocalUserIsAdmin)
-            search.Name = "Admin";
+            search = new StaffSearchDto(SortBy.NameAsc, "Admin", null, null, null, null);
+        else
+            search = new StaffSearchDto(SortBy.NameAsc, "Limited", null, null, null, null);
 
         var staffId = (await _staffService.GetListAsync(search)).First().Id;
 

--- a/src/WebApp/Pages/Admin/Maintenance/Offices/Index.cshtml
+++ b/src/WebApp/Pages/Admin/Maintenance/Offices/Index.cshtml
@@ -1,5 +1,6 @@
 ﻿@page
 @using Sbeap.Domain.Identity
+@using Sbeap.WebApp.Pages.Shared.DisplayTemplates
 @model IndexModel
 @{
     ViewData["Title"] = $"Site Maintenance: {IndexModel.ThisOption.PluralName}";
@@ -62,7 +63,7 @@ else
                     }
                 </td>
                 <td>
-                    @Html.DisplayFor(m => item.Active)
+                    @Html.DisplayFor(m => item.Active, DisplayTemplate.BoolActive)
                 </td>
             </tr>
         }

--- a/src/WebApp/Pages/Admin/Users/Index.cshtml
+++ b/src/WebApp/Pages/Admin/Users/Index.cshtml
@@ -108,7 +108,7 @@
                         </td>
                         <td>@item.Email</td>
                         <td>@Html.DisplayFor(m => item.OfficeName, DisplayTemplate.StringOrNone)</td>
-                        <td>@Html.DisplayFor(m => item.Active)</td>
+                        <td>@Html.DisplayFor(m => item.Active, DisplayTemplate.BoolActive)</td>
                     </tr>
                 }
                 </tbody>

--- a/src/WebApp/Pages/Admin/Users/Index.cshtml.cs
+++ b/src/WebApp/Pages/Admin/Users/Index.cshtml.cs
@@ -43,14 +43,11 @@ public class IndexModel : PageModel
 
     public async Task<IActionResult> OnGetSearchAsync(StaffSearchDto spec, [FromQuery] int p = 1)
     {
-        spec.TrimAll();
-        var paging = new PaginatedRequest(p, GlobalConstants.PageSize, spec.Sort.GetDescription());
-
-        Spec = spec;
-        ShowResults = true;
-
+        Spec = spec.TrimAll();
         await PopulateSelectListsAsync();
-        SearchResults = await _staffService.SearchAsync(spec, paging);
+        var paging = new PaginatedRequest(p, GlobalConstants.PageSize, Spec.Sort.GetDescription());
+        SearchResults = await _staffService.SearchAsync(Spec, paging);
+        ShowResults = true;
         return Page();
     }
 

--- a/src/WebApp/Pages/Customers/Index.cshtml.cs
+++ b/src/WebApp/Pages/Customers/Index.cshtml.cs
@@ -34,13 +34,10 @@ public class IndexModel : PageModel
 
     public async Task<IActionResult> OnGetSearchAsync(CustomerSearchDto spec, [FromQuery] int p = 1)
     {
-        spec.TrimAll();
-        var paging = new PaginatedRequest(p, GlobalConstants.PageSize, spec.Sort.GetDescription());
-
-        Spec = spec;
+        Spec = spec.TrimAll();
+        var paging = new PaginatedRequest(p, GlobalConstants.PageSize, Spec.Sort.GetDescription());
+        SearchResults = await _service.SearchAsync(Spec, paging);
         ShowResults = true;
-
-        SearchResults = await _service.SearchAsync(spec, paging);
         return Page();
     }
 }

--- a/tests/AppServicesTests/Cases/CaseworkFilterTests.cs
+++ b/tests/AppServicesTests/Cases/CaseworkFilterTests.cs
@@ -6,15 +6,17 @@ namespace AppServicesTests.Cases;
 
 public class CaseworkFilterTests
 {
+    private static CaseworkSearchDto DefaultCaseworkSearch => new(CaseworkSortBy.CustomerAsc, null, null, null, null,
+        null, null, null, null, null, null, null);
+
     [Test]
     public void DefaultFilter_ReturnsAllNotDeleted()
     {
         // Arrange
-        var spec = new CaseworkSearchDto();
         var expected = CaseworkData.GetCases.Where(e => !e.IsDeleted);
 
         // Act
-        var predicate = CaseworkFilters.CaseworkSearchPredicate(spec);
+        var predicate = CaseworkFilters.CaseworkSearchPredicate(DefaultCaseworkSearch);
         var result = CaseworkData.GetCases
             .Where(predicate.Compile()).AsQueryable().ToList();
 
@@ -26,7 +28,7 @@ public class CaseworkFilterTests
     public void DeletedSpec_ReturnsAllDeleted()
     {
         // Arrange
-        var spec = new CaseworkSearchDto { DeletedStatus = CaseDeletedStatus.Deleted };
+        var spec = DefaultCaseworkSearch with { DeletedStatus = CaseDeletedStatus.Deleted };
         var expected = CaseworkData.GetCases.Where(e => e.IsDeleted);
 
         // Act
@@ -42,7 +44,7 @@ public class CaseworkFilterTests
     public void DeletedSpecNeutral_ReturnsAll()
     {
         // Arrange
-        var spec = new CaseworkSearchDto { DeletedStatus = CaseDeletedStatus.All };
+        var spec = DefaultCaseworkSearch with { DeletedStatus = CaseDeletedStatus.All };
 
         // Act
         var predicate = CaseworkFilters.CaseworkSearchPredicate(spec);
@@ -57,7 +59,7 @@ public class CaseworkFilterTests
     public void StatusOpen_ReturnsFilteredList()
     {
         // Arrange
-        var spec = new CaseworkSearchDto { Status = CaseStatus.Open };
+        var spec = DefaultCaseworkSearch with { Status = CaseStatus.Open };
         var expected = CaseworkData.GetCases.Where(e => e is { IsDeleted: false, IsClosed: false });
 
         // Act
@@ -73,7 +75,7 @@ public class CaseworkFilterTests
     public void StatusClosed_ReturnsFilteredList()
     {
         // Arrange
-        var spec = new CaseworkSearchDto { Status = CaseStatus.Closed };
+        var spec = DefaultCaseworkSearch with { Status = CaseStatus.Closed };
         var expected = CaseworkData.GetCases.Where(e => e is { IsDeleted: false, IsClosed: true });
 
         // Act
@@ -90,7 +92,7 @@ public class CaseworkFilterTests
     {
         // Arrange
         var referenceItem = CaseworkData.GetCases.First(e => !e.IsDeleted && !string.IsNullOrEmpty(e.Customer.Name));
-        var spec = new CaseworkSearchDto { CustomerName = referenceItem.Customer.Name };
+        var spec = DefaultCaseworkSearch with { CustomerName = referenceItem.Customer.Name };
         var expected = CaseworkData.GetCases.Where(e => !e.IsDeleted && e.Customer.Name == referenceItem.Customer.Name);
 
         // Act
@@ -107,7 +109,7 @@ public class CaseworkFilterTests
     {
         // Arrange
         var referenceItem = CaseworkData.GetCases.First(e => !e.IsDeleted && !string.IsNullOrEmpty(e.Description));
-        var spec = new CaseworkSearchDto { Description = referenceItem.Description };
+        var spec = DefaultCaseworkSearch with { Description = referenceItem.Description };
         var expected = CaseworkData.GetCases.Where(e => !e.IsDeleted && e.Description == referenceItem.Description);
 
         // Act
@@ -124,8 +126,10 @@ public class CaseworkFilterTests
     {
         // Arrange
         var referenceItem = CaseworkData.GetCases.First(e => !e.IsDeleted);
-        var spec = new CaseworkSearchDto
-            { OpenedFrom = referenceItem.CaseOpenedDate, OpenedTo = referenceItem.CaseOpenedDate };
+        var spec = DefaultCaseworkSearch with
+        {
+            OpenedFrom = referenceItem.CaseOpenedDate, OpenedTo = referenceItem.CaseOpenedDate
+        };
 
         var expected = CaseworkData.GetCases
             .Where(e => !e.IsDeleted && e.CaseOpenedDate == referenceItem.CaseOpenedDate);
@@ -144,8 +148,10 @@ public class CaseworkFilterTests
     {
         // Arrange
         var referenceItem = CaseworkData.GetCases.First(e => e is { IsDeleted: false, IsClosed: true });
-        var spec = new CaseworkSearchDto
-            { ClosedFrom = referenceItem.CaseClosedDate, ClosedTo = referenceItem.CaseClosedDate };
+        var spec = DefaultCaseworkSearch with
+        {
+            ClosedFrom = referenceItem.CaseClosedDate, ClosedTo = referenceItem.CaseClosedDate
+        };
 
         var expected = CaseworkData.GetCases
             .Where(e => !e.IsDeleted && e.CaseClosedDate == referenceItem.CaseClosedDate);

--- a/tests/AppServicesTests/Cases/Search.cs
+++ b/tests/AppServicesTests/Cases/Search.cs
@@ -15,6 +15,9 @@ namespace AppServicesTests.Cases;
 
 public class Search
 {
+    private static CaseworkSearchDto DefaultCaseworkSearch => new(CaseworkSortBy.CustomerAsc, null, null, null, null,
+        null, null, null, null, null, null, null);
+
     [Test]
     public async Task WhenItemsExist_ReturnsPagedList()
     {
@@ -35,7 +38,7 @@ public class Search
             Mock.Of<ICustomerRepository>(), Mock.Of<IAgencyRepository>());
 
         // Act
-        var result = await appService.SearchAsync(Mock.Of<CaseworkSearchDto>(), paging, CancellationToken.None);
+        var result = await appService.SearchAsync(DefaultCaseworkSearch, paging, CancellationToken.None);
 
         // Assert
         using (new AssertionScope())
@@ -65,7 +68,7 @@ public class Search
             Mock.Of<ICustomerRepository>(), Mock.Of<IAgencyRepository>());
 
         // Act
-        var result = await appService.SearchAsync(Mock.Of<CaseworkSearchDto>(), paging, CancellationToken.None);
+        var result = await appService.SearchAsync(DefaultCaseworkSearch, paging, CancellationToken.None);
 
         // Assert
         using (new AssertionScope())

--- a/tests/AppServicesTests/Customers/ContactCreateValidatorTests.cs
+++ b/tests/AppServicesTests/Customers/ContactCreateValidatorTests.cs
@@ -1,16 +1,20 @@
 ﻿using FluentValidation.TestHelper;
 using Sbeap.AppServices.Customers.Dto;
 using Sbeap.AppServices.Customers.Validators;
+using Sbeap.Domain.ValueObjects;
 using Sbeap.TestData.Constants;
 
 namespace AppServicesTests.Customers;
 
 public class ContactCreateValidatorTests
 {
+    private static ContactCreateDto EmptyContactCreateDto => new(null, null, null, null, null, null,
+        new IncompleteAddress(), new PhoneNumber());
+
     [Test]
     public async Task ValidDto_ReturnsAsValid()
     {
-        var model = new ContactCreateDto
+        var model = EmptyContactCreateDto with
         {
             GivenName = TextData.ValidName,
             Email = TextData.ValidEmail,
@@ -25,10 +29,9 @@ public class ContactCreateValidatorTests
     [Test]
     public async Task EmptyContact_ReturnsAsInvalid()
     {
-        var model = ContactCreateDto.EmptyContact;
         var validator = new ContactCreateValidator();
 
-        var result = await validator.TestValidateAsync(model);
+        var result = await validator.TestValidateAsync(EmptyContactCreateDto);
 
         result.ShouldHaveValidationErrorFor(e => e.Title);
     }
@@ -36,7 +39,7 @@ public class ContactCreateValidatorTests
     [Test]
     public async Task InvalidEmail_ReturnsAsInvalid()
     {
-        var model = new ContactCreateDto
+        var model = EmptyContactCreateDto with
         {
             Title = TextData.Phrase,
             Email = TextData.NonExistentName, // invalid as email
@@ -51,7 +54,10 @@ public class ContactCreateValidatorTests
     [Test]
     public async Task MissingNameOrTitle_ReturnsAsInvalid()
     {
-        var model = new ContactCreateDto { Email = TextData.ValidEmail };
+        var model = EmptyContactCreateDto with
+        {
+            Email = TextData.ValidEmail,
+        };
         var validator = new ContactCreateValidator();
 
         var result = await validator.TestValidateAsync(model);

--- a/tests/AppServicesTests/Customers/CustomerCreateValidatorTests.cs
+++ b/tests/AppServicesTests/Customers/CustomerCreateValidatorTests.cs
@@ -1,19 +1,26 @@
 ﻿using FluentValidation.TestHelper;
 using Sbeap.AppServices.Customers.Dto;
 using Sbeap.AppServices.Customers.Validators;
+using Sbeap.Domain.ValueObjects;
 using Sbeap.TestData.Constants;
 
 namespace AppServicesTests.Customers;
 
 public class CustomerCreateValidatorTests
 {
+    private static ContactCreateDto EmptyContactCreate => new(null, null, null, null, null, null,
+        new IncompleteAddress(), new PhoneNumber());
+
+    private static CustomerCreateDto EmptyCustomerCreate => new(string.Empty, null, null, null, new IncompleteAddress(),
+        new IncompleteAddress(), EmptyContactCreate);
+
     [Test]
     public async Task ValidDtoWithEmptyContact_ReturnsAsValid()
     {
-        var model = new CustomerCreateDto
+        var model = EmptyCustomerCreate with
         {
             Name = TextData.ValidName,
-            Contact = ContactCreateDto.EmptyContact,
+            Contact = EmptyContactCreate,
         };
         var validator = new CustomerCreateValidator();
 
@@ -25,10 +32,10 @@ public class CustomerCreateValidatorTests
     [Test]
     public async Task ValidDtoWithValidContact_ReturnsAsValid()
     {
-        var model = new CustomerCreateDto
+        var model = EmptyCustomerCreate with
         {
             Name = TextData.ValidName,
-            Contact = new ContactCreateDto { Title = TextData.Phrase },
+            Contact = EmptyContactCreate with { Title = TextData.Phrase },
         };
         var validator = new CustomerCreateValidator();
 
@@ -40,10 +47,10 @@ public class CustomerCreateValidatorTests
     [Test]
     public async Task NameTooShort_ReturnsAsInvalid()
     {
-        var model = new CustomerCreateDto
+        var model = EmptyCustomerCreate with
         {
             Name = TextData.ShortName,
-            Contact = ContactCreateDto.EmptyContact,
+            Contact = EmptyContactCreate,
         };
         var validator = new CustomerCreateValidator();
 
@@ -55,11 +62,11 @@ public class CustomerCreateValidatorTests
     [Test]
     public async Task InvalidWebsite_ReturnsAsInvalid()
     {
-        var model = new CustomerCreateDto
+        var model = EmptyCustomerCreate with
         {
             Name = TextData.ValidName,
             Website = TextData.NonExistentName, // invalid as website
-            Contact = ContactCreateDto.EmptyContact,
+            Contact = EmptyContactCreate,
         };
         var validator = new CustomerCreateValidator();
 
@@ -71,10 +78,10 @@ public class CustomerCreateValidatorTests
     [Test]
     public async Task InvalidContactEmail_ReturnsAsInvalid()
     {
-        var model = new CustomerCreateDto
+        var model = EmptyCustomerCreate with
         {
             Name = TextData.ValidName,
-            Contact = new ContactCreateDto
+            Contact = EmptyContactCreate with
             {
                 Title = TextData.Phrase,
                 Email = TextData.NonExistentName, // invalid as email
@@ -90,10 +97,10 @@ public class CustomerCreateValidatorTests
     [Test]
     public async Task ContactWithoutNameOrTitle_ReturnsAsInvalid()
     {
-        var model = new CustomerCreateDto
+        var model = EmptyCustomerCreate with
         {
             Name = TextData.ValidName,
-            Contact = new ContactCreateDto { Email = TextData.ValidEmail },
+            Contact = EmptyContactCreate with { Email = TextData.ValidEmail },
         };
         var validator = new CustomerCreateValidator();
 

--- a/tests/AppServicesTests/Customers/CustomerFilterTests.cs
+++ b/tests/AppServicesTests/Customers/CustomerFilterTests.cs
@@ -6,11 +6,13 @@ namespace AppServicesTests.Customers;
 
 public class CustomerFilterTests
 {
+    private static CustomerSearchDto DefaultCustomerSearchDto => new(CustomerSortBy.NameAsc, null, null, null, null);
+
     [Test]
     public void DefaultFilter_ReturnsAllNotDeleted()
     {
         // Arrange
-        var spec = new CustomerSearchDto();
+        var spec = DefaultCustomerSearchDto;
         var expected = CustomerData.GetCustomers.Where(e => !e.IsDeleted);
 
         // Act
@@ -26,7 +28,7 @@ public class CustomerFilterTests
     public void DeletedSpec_ReturnsAllDeleted()
     {
         // Arrange
-        var spec = new CustomerSearchDto { DeletedStatus = CustomerDeletedStatus.Deleted };
+        var spec = DefaultCustomerSearchDto with { DeletedStatus = CustomerDeletedStatus.Deleted };
         var expected = CustomerData.GetCustomers.Where(e => e.IsDeleted);
 
         // Act
@@ -42,7 +44,7 @@ public class CustomerFilterTests
     public void DeletedSpecNeutral_ReturnsAll()
     {
         // Arrange
-        var spec = new CustomerSearchDto { DeletedStatus = CustomerDeletedStatus.All };
+        var spec = DefaultCustomerSearchDto with { DeletedStatus = CustomerDeletedStatus.All };
 
         // Act
         var predicate = CustomerFilters.CustomerSearchPredicate(spec);
@@ -58,7 +60,7 @@ public class CustomerFilterTests
     {
         // Arrange
         var referenceItem = CustomerData.GetCustomers.First(e => !e.IsDeleted);
-        var spec = new CustomerSearchDto { Name = referenceItem.Name };
+        var spec = DefaultCustomerSearchDto with { Name = referenceItem.Name };
         var expected = CustomerData.GetCustomers.Where(e => !e.IsDeleted && e.Name == referenceItem.Name);
 
         // Act
@@ -75,7 +77,7 @@ public class CustomerFilterTests
     {
         // Arrange
         var referenceItem = CustomerData.GetCustomers.First(e => !e.IsDeleted && !string.IsNullOrEmpty(e.County));
-        var spec = new CustomerSearchDto { County = referenceItem.County };
+        var spec = DefaultCustomerSearchDto with { County = referenceItem.County };
         var expected = CustomerData.GetCustomers.Where(e => !e.IsDeleted && e.County == referenceItem.County);
 
         // Act
@@ -92,7 +94,7 @@ public class CustomerFilterTests
     {
         // Arrange
         var referenceItem = CustomerData.GetCustomers.First(e => !e.IsDeleted && !string.IsNullOrEmpty(e.Description));
-        var spec = new CustomerSearchDto { Description = referenceItem.Description };
+        var spec = DefaultCustomerSearchDto with { Description = referenceItem.Description };
         var expected = CustomerData.GetCustomers.Where(e => !e.IsDeleted && e.Description == referenceItem.Description);
 
         // Act

--- a/tests/AppServicesTests/Customers/CustomerViewPermissions.cs
+++ b/tests/AppServicesTests/Customers/CustomerViewPermissions.cs
@@ -11,6 +11,8 @@ public class CustomerViewPermissions
 {
     private readonly CustomerOperation[] _requirements = { CustomerOperation.ManageDeletions };
 
+    private static CustomerViewDto EmptyCustomerView => new();
+
     [Test]
     public async Task ManageDeletions_WhenAllowed_Succeeds()
     {
@@ -19,8 +21,7 @@ public class CustomerViewPermissions
         // The value for `authenticationType` parameter causes `ClaimsIdentity.IsAuthenticated` to be set to `true`.
         var user = new ClaimsPrincipal(
             new ClaimsIdentity(new Claim[] { new(ClaimTypes.Role, RoleName.Admin) }, "Basic"));
-        var resource = new CustomerViewDto();
-        var context = new AuthorizationHandlerContext(_requirements, user, resource);
+        var context = new AuthorizationHandlerContext(_requirements, user, EmptyCustomerView);
         var handler = new CustomerViewPermissionsHandler();
 
         // Act
@@ -38,8 +39,7 @@ public class CustomerViewPermissions
         // This `ClaimsPrincipal` is not authenticated.
         var user = new ClaimsPrincipal(
             new ClaimsIdentity(new Claim[] { new(ClaimTypes.Role, RoleName.Admin) }));
-        var resource = new CustomerViewDto();
-        var context = new AuthorizationHandlerContext(_requirements, user, resource);
+        var context = new AuthorizationHandlerContext(_requirements, user, EmptyCustomerView);
         var handler = new CustomerViewPermissionsHandler();
 
         // Act
@@ -56,8 +56,7 @@ public class CustomerViewPermissions
 
         // This `ClaimsPrincipal` is authenticated but does not have the Admin role.
         var user = new ClaimsPrincipal(new ClaimsIdentity("Basic"));
-        var resource = new CustomerViewDto();
-        var context = new AuthorizationHandlerContext(_requirements, user, resource);
+        var context = new AuthorizationHandlerContext(_requirements, user, EmptyCustomerView);
         var handler = new CustomerViewPermissionsHandler();
 
         // Act

--- a/tests/AppServicesTests/Customers/Search.cs
+++ b/tests/AppServicesTests/Customers/Search.cs
@@ -14,6 +14,8 @@ namespace AppServicesTests.Customers;
 
 public class Search
 {
+    private static CustomerSearchDto DefaultCustomerSearchDto => new(CustomerSortBy.NameAsc, null, null, null, null);
+
     [Test]
     public async Task WhenItemsExist_ReturnsPagedList()
     {
@@ -34,7 +36,7 @@ public class Search
             Mock.Of<IContactRepository>());
 
         // Act
-        var result = await appService.SearchAsync(Mock.Of<CustomerSearchDto>(), paging, CancellationToken.None);
+        var result = await appService.SearchAsync(DefaultCustomerSearchDto, paging, CancellationToken.None);
 
         // Assert
         using (new AssertionScope())
@@ -64,7 +66,7 @@ public class Search
             Mock.Of<IContactRepository>());
 
         // Act
-        var result = await appService.SearchAsync(Mock.Of<CustomerSearchDto>(), paging, CancellationToken.None);
+        var result = await appService.SearchAsync(DefaultCustomerSearchDto, paging, CancellationToken.None);
 
         // Assert
         using (new AssertionScope())

--- a/tests/AppServicesTests/Customers/UpdateValidator.cs
+++ b/tests/AppServicesTests/Customers/UpdateValidator.cs
@@ -1,16 +1,20 @@
 ﻿using FluentValidation.TestHelper;
 using Sbeap.AppServices.Customers.Dto;
 using Sbeap.AppServices.Customers.Validators;
+using Sbeap.Domain.ValueObjects;
 using Sbeap.TestData.Constants;
 
 namespace AppServicesTests.Customers;
 
 public class UpdateValidator
 {
+    private static CustomerUpdateDto DefaultCustomerUpdate => new(Guid.Empty, string.Empty, string.Empty, null,
+        new IncompleteAddress(), new IncompleteAddress());
+
     [Test]
     public async Task ValidDto_ReturnsAsValid()
     {
-        var model = new CustomerUpdateDto { Name = TextData.ValidName };
+        var model = DefaultCustomerUpdate with { Name = TextData.ValidName };
         var validator = new CustomerUpdateValidator();
 
         var result = await validator.TestValidateAsync(model);
@@ -21,7 +25,7 @@ public class UpdateValidator
     [Test]
     public async Task NameTooShort_ReturnsAsInvalid()
     {
-        var model = new CustomerUpdateDto { Name = TextData.ShortName };
+        var model = DefaultCustomerUpdate with { Name = TextData.ShortName };
         var validator = new CustomerUpdateValidator();
 
         var result = await validator.TestValidateAsync(model);

--- a/tests/AppServicesTests/Offices/Create.cs
+++ b/tests/AppServicesTests/Offices/Create.cs
@@ -22,7 +22,7 @@ public class Create
             .ReturnsAsync((ApplicationUser?)null);
         var appService = new OfficeService(repoMock.Object, managerMock.Object,
             AppServicesTestsSetup.Mapper!, userServiceMock.Object);
-        var resource = new OfficeCreateDto { Name = TextData.ValidName };
+        var resource = new OfficeCreateDto(TextData.ValidName);
 
         var result = await appService.CreateAsync(resource);
 

--- a/tests/AppServicesTests/Offices/CreateValidator.cs
+++ b/tests/AppServicesTests/Offices/CreateValidator.cs
@@ -14,7 +14,7 @@ public class CreateValidator
         var repoMock = new Mock<IOfficeRepository>();
         repoMock.Setup(l => l.FindByNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((Office?)null);
-        var model = new OfficeCreateDto { Name = TextData.ValidName };
+        var model = new OfficeCreateDto(TextData.ValidName);
 
         var validator = new OfficeCreateValidator(repoMock.Object);
         var result = await validator.TestValidateAsync(model);
@@ -28,7 +28,7 @@ public class CreateValidator
         var repoMock = new Mock<IOfficeRepository>();
         repoMock.Setup(l => l.FindByNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Office(Guid.Empty, TextData.ValidName));
-        var model = new OfficeCreateDto { Name = TextData.ValidName };
+        var model = new OfficeCreateDto(TextData.ValidName);
 
         var validator = new OfficeCreateValidator(repoMock.Object);
         var result = await validator.TestValidateAsync(model);
@@ -43,7 +43,7 @@ public class CreateValidator
         var repoMock = new Mock<IOfficeRepository>();
         repoMock.Setup(l => l.FindByNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((Office?)null);
-        var model = new OfficeCreateDto { Name = TextData.ShortName };
+        var model = new OfficeCreateDto(TextData.ShortName);
 
         var validator = new OfficeCreateValidator(repoMock.Object);
         var result = await validator.TestValidateAsync(model);

--- a/tests/AppServicesTests/Offices/UpdateValidator.cs
+++ b/tests/AppServicesTests/Offices/UpdateValidator.cs
@@ -14,12 +14,7 @@ public class UpdateValidator
         var repoMock = new Mock<IOfficeRepository>();
         repoMock.Setup(l => l.FindByNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((Office?)null);
-        var model = new OfficeUpdateDto
-        {
-            Id = Guid.Empty,
-            Name = TextData.ValidName,
-            Active = true,
-        };
+        var model = new OfficeUpdateDto(Id: Guid.Empty, Name: TextData.ValidName, Active: true);
 
         var validator = new OfficeUpdateValidator(repoMock.Object);
         var result = await validator.TestValidateAsync(model);
@@ -33,12 +28,7 @@ public class UpdateValidator
         var repoMock = new Mock<IOfficeRepository>();
         repoMock.Setup(l => l.FindByNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Office(Guid.NewGuid(), TextData.ValidName));
-        var model = new OfficeUpdateDto
-        {
-            Id = Guid.Empty,
-            Name = TextData.ValidName,
-            Active = true,
-        };
+        var model = new OfficeUpdateDto(Id: Guid.Empty, Name: TextData.ValidName, Active: true);
 
         var validator = new OfficeUpdateValidator(repoMock.Object);
         var result = await validator.TestValidateAsync(model);
@@ -53,12 +43,7 @@ public class UpdateValidator
         var repoMock = new Mock<IOfficeRepository>();
         repoMock.Setup(l => l.FindByNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Office(Guid.Empty, TextData.ValidName));
-        var model = new OfficeUpdateDto
-        {
-            Id = Guid.Empty,
-            Name = TextData.ValidName,
-            Active = true,
-        };
+        var model = new OfficeUpdateDto(Id: Guid.Empty, Name: TextData.ValidName, Active: true);
 
         var validator = new OfficeUpdateValidator(repoMock.Object);
         var result = await validator.TestValidateAsync(model);
@@ -72,7 +57,7 @@ public class UpdateValidator
         var repoMock = new Mock<IOfficeRepository>();
         repoMock.Setup(l => l.FindByNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((Office?)null);
-        var model = new OfficeUpdateDto { Name = TextData.ShortName };
+        var model = new OfficeUpdateDto(Id: Guid.Empty, Name: TextData.ShortName, Active: true);
 
         var validator = new OfficeUpdateValidator(repoMock.Object);
         var result = await validator.TestValidateAsync(model);

--- a/tests/AppServicesTests/Staff/StaffDtoTests.cs
+++ b/tests/AppServicesTests/Staff/StaffDtoTests.cs
@@ -10,23 +10,26 @@ public class StaffDtoTests
     [Test]
     public void DisplayName_TrimAll_TrimsItems()
     {
-        var staffSearchDto = new StaffSearchDto { Name = " abc ", Email = " def " };
+        var staffSearchDto = new StaffSearchDto(SortBy.NameAsc, " abc ", " def ", null, null, null);
 
-        staffSearchDto.TrimAll();
+        var result = staffSearchDto.TrimAll();
 
         using (new AssertionScope())
         {
-            staffSearchDto.Name.Should().Be("abc");
-            staffSearchDto.Email.Should().Be("def");
+            result.Name.Should().Be("abc");
+            result.Email.Should().Be("def");
         }
     }
+
+    private static StaffViewDto ValidStaffView =>
+        new(Guid.Empty.ToString(), string.Empty, string.Empty, null, null, null, true);
 
     [TestCase("abc", "def", "abc def")]
     [TestCase("abc", "", "abc")]
     [TestCase("", "def", "def")]
     public void DisplayName_ExpectedBehavior(string givenName, string familyName, string expected)
     {
-        var staffViewDto = new StaffViewDto { GivenName = givenName, FamilyName = familyName };
+        var staffViewDto = ValidStaffView with { GivenName = givenName, FamilyName = familyName };
         staffViewDto.Name.Should().Be(expected);
     }
 
@@ -35,19 +38,19 @@ public class StaffDtoTests
     [TestCase("", "def", "def")]
     public void SortableFullName_ExpectedBehavior(string givenName, string familyName, string expected)
     {
-        var staffViewDto = new StaffViewDto { GivenName = givenName, FamilyName = familyName };
+        var staffViewDto = ValidStaffView with { GivenName = givenName, FamilyName = familyName };
         staffViewDto.SortableFullName.Should().Be(expected);
     }
 
     [Test]
     public void AsUpdateDto_ExpectedBehavior()
     {
-        var staffViewDto = new StaffViewDto
+        var staffViewDto = ValidStaffView with
         {
             Id = Guid.NewGuid().ToString(),
             Active = true,
             Phone = TextData.ValidPhoneNumber,
-            Office = new OfficeViewDto { Id = Guid.NewGuid() },
+            Office = new OfficeViewDto(Guid.NewGuid(), TextData.ValidName, true),
         };
 
         var result = staffViewDto.AsUpdateDto();

--- a/tests/AppServicesTests/Staff/StaffFilters.cs
+++ b/tests/AppServicesTests/Staff/StaffFilters.cs
@@ -6,13 +6,14 @@ namespace AppServicesTests.Staff;
 
 public class StaffFilters
 {
+    private static StaffSearchDto DefaultStaffSearch => new(SortBy.NameAsc, null, null, null, null, null);
+
     [Test]
     public void DefaultFilter_ReturnsAllActive()
     {
-        var spec = new StaffSearchDto();
         var expected = UserData.GetUsers.Where(e => e.Active);
 
-        var result = UserData.GetUsers.AsQueryable().ApplyFilter(spec);
+        var result = UserData.GetUsers.AsQueryable().ApplyFilter(DefaultStaffSearch);
 
         result.Should().BeEquivalentTo(expected);
     }
@@ -21,7 +22,7 @@ public class StaffFilters
     public void NameFilter_ReturnsMatches()
     {
         var name = UserData.GetUsers.First(e => e.Active).GivenName;
-        var spec = new StaffSearchDto { Name = name };
+        var spec = DefaultStaffSearch with { Name = name };
         var expected = UserData.GetUsers
             .Where(e => e.Active &&
                 (string.Equals(e.GivenName, name, StringComparison.CurrentCultureIgnoreCase) ||
@@ -36,7 +37,7 @@ public class StaffFilters
     public void EmailFilter_ReturnsMatches()
     {
         var email = UserData.GetUsers.First(e => e.Active).Email;
-        var spec = new StaffSearchDto { Email = email };
+        var spec = DefaultStaffSearch with { Email = email };
         var expected = UserData.GetUsers
             .Where(e => e.Active && e.Email == email);
 
@@ -49,7 +50,7 @@ public class StaffFilters
     public void OfficeFilter_ReturnsMatches()
     {
         var office = UserData.GetUsers.First().Office;
-        var spec = new StaffSearchDto { Office = office!.Id, Status = SearchStaffStatus.All };
+        var spec = DefaultStaffSearch with { Office = office!.Id, Status = SearchStaffStatus.All };
         var expected = UserData.GetUsers
             .Where(e => e.Office!.Id == office.Id);
 
@@ -61,7 +62,7 @@ public class StaffFilters
     [Test]
     public void InactiveFilter_ReturnsAllInactive()
     {
-        var spec = new StaffSearchDto { Status = SearchStaffStatus.Inactive };
+        var spec = DefaultStaffSearch with { Status = SearchStaffStatus.Inactive };
         var expected = UserData.GetUsers.Where(e => !e.Active);
 
         var result = UserData.GetUsers.AsQueryable().ApplyFilter(spec);
@@ -72,7 +73,7 @@ public class StaffFilters
     [Test]
     public void StatusAllFilter_ReturnsAll()
     {
-        var spec = new StaffSearchDto { Status = SearchStaffStatus.All };
+        var spec = DefaultStaffSearch with { Status = SearchStaffStatus.All };
         var result = UserData.GetUsers.AsQueryable().ApplyFilter(spec);
         result.Should().BeEquivalentTo(UserData.GetUsers);
     }

--- a/tests/EfRepositoryTests/BaseWriteRepository/Delete.cs
+++ b/tests/EfRepositoryTests/BaseWriteRepository/Delete.cs
@@ -34,7 +34,7 @@ public class Delete
         // (Still part of arrange...)
         var getResult = await _repository.FindAsync(item.Id);
         getResult.Should().BeEquivalentTo(item);
-
+       
         // Act
         await _repository.DeleteAsync(item);
         _repositoryHelper.ClearChangeTracker();

--- a/tests/WebAppTests/Api/OfficeApiTests.cs
+++ b/tests/WebAppTests/Api/OfficeApiTests.cs
@@ -9,11 +9,12 @@ namespace WebAppTests.Api;
 [TestFixture]
 public class OfficeApiTests
 {
+    private static OfficeViewDto ValidOfficeView => new(Guid.Empty, TextData.ValidName, true);
+
     [Test]
     public async Task ListOffices_ReturnsListOfOffices()
     {
-        List<OfficeViewDto> officeList = new()
-            { new OfficeViewDto { Id = Guid.Empty, Name = TextData.ValidName } };
+        List<OfficeViewDto> officeList = new() { ValidOfficeView };
         var service = new Mock<IOfficeService>();
         service.Setup(l => l.GetListAsync(CancellationToken.None))
             .ReturnsAsync(officeList);
@@ -27,10 +28,9 @@ public class OfficeApiTests
     [Test]
     public async Task GetOffice_ReturnsOfficeView()
     {
-        var item = Mock.Of<OfficeViewDto>();
         var service = new Mock<IOfficeService>();
         service.Setup(l => l.FindAsync(Guid.Empty, CancellationToken.None))
-            .ReturnsAsync(item);
+            .ReturnsAsync(ValidOfficeView);
         var apiController = new OfficeApiController(service.Object);
 
         var response = await apiController.GetOfficeAsync(Guid.Empty);
@@ -40,7 +40,7 @@ public class OfficeApiTests
             response.Result.Should().BeOfType<OkObjectResult>();
             var result = response.Result as OkObjectResult;
             result.Should().NotBeNull();
-            result?.Value.Should().Be(item);
+            result?.Value.Should().Be(ValidOfficeView);
         }
     }
 

--- a/tests/WebAppTests/Pages/Account/EditTests.cs
+++ b/tests/WebAppTests/Pages/Account/EditTests.cs
@@ -17,20 +17,22 @@ namespace WebAppTests.Pages.Account;
 
 public class EditTests
 {
-    private static readonly StaffViewDto StaffViewTest = new()
-    {
-        Id = Guid.Empty.ToString(),
-        Active = true,
-        Email = TextData.ValidEmail,
-        GivenName = TextData.ValidName,
-        FamilyName = TextData.ValidName,
-    };
+    private static readonly StaffViewDto StaffViewTest = new(
+        Guid.Empty.ToString(),
+        TextData.ValidName,
+        TextData.ValidName,
+        TextData.ValidEmail,
+        null,
+        null,
+        true
+    );
 
-    private static readonly StaffUpdateDto StaffUpdateTest = new()
-    {
-        Id = Guid.Empty.ToString(),
-        Active = true,
-    };
+    private static readonly StaffUpdateDto StaffUpdateTest = new(
+        Guid.Empty.ToString(),
+        null,
+        null,
+        true
+    );
 
     [Test]
     public async Task OnGet_PopulatesThePageModel()

--- a/tests/WebAppTests/Pages/Admin/Maintenance/Offices/AddTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Maintenance/Offices/AddTests.cs
@@ -13,7 +13,7 @@ namespace WebAppTests.Pages.Admin.Maintenance.Offices;
 
 public class AddTests
 {
-    private static readonly OfficeCreateDto ItemTest = new() { Name = TextData.ValidName };
+    private static readonly OfficeCreateDto ItemTest = new(TextData.ValidName);
 
     [Test]
     public async Task OnPost_GivenSuccess_ReturnsRedirectWithDisplayMessage()

--- a/tests/WebAppTests/Pages/Admin/Maintenance/Offices/EditTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Maintenance/Offices/EditTests.cs
@@ -13,7 +13,7 @@ namespace WebAppTests.Pages.Admin.Maintenance.Offices;
 
 public class EditTests
 {
-    private static readonly OfficeUpdateDto ItemTest = new() { Id = Guid.Empty, Name = TextData.ValidName };
+    private static readonly OfficeUpdateDto ItemTest = new(Guid.Empty, TextData.ValidName, true);
 
     [Test]
     public async Task OnGet_ReturnsWithItem()

--- a/tests/WebAppTests/Pages/Admin/Maintenance/Offices/IndexTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Maintenance/Offices/IndexTests.cs
@@ -11,7 +11,7 @@ namespace WebAppTests.Pages.Admin.Maintenance.Offices;
 public class IndexTests
 {
     private static readonly List<OfficeViewDto> ListTest = new()
-        { new OfficeViewDto { Id = Guid.Empty, Name = TextData.ValidName } };
+        { new OfficeViewDto(Guid.Empty, TextData.ValidName, true) };
 
     [Test]
     public async Task OnGet_ReturnsWithList()

--- a/tests/WebAppTests/Pages/Admin/Users/DetailsTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Users/DetailsTests.cs
@@ -16,13 +16,16 @@ public class DetailsTests
     [Test]
     public async Task OnGet_PopulatesThePageModel()
     {
-        var staffView = new StaffViewDto
-        {
-            Id = Guid.Empty.ToString(),
-            Email = TextData.ValidEmail,
-            GivenName = TextData.ValidName,
-            FamilyName = TextData.ValidName,
-        };
+        var staffView = new StaffViewDto(
+            Guid.Empty.ToString(),
+            TextData.ValidName,
+            TextData.ValidName,
+            TextData.ValidEmail,
+            null,
+            null,
+            true
+        );
+
         var serviceMock = new Mock<IStaffService>();
         serviceMock.Setup(l => l.FindAsync(It.IsAny<string>()))
             .ReturnsAsync(staffView);

--- a/tests/WebAppTests/Pages/Admin/Users/EditRolesTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Users/EditRolesTests.cs
@@ -15,16 +15,17 @@ namespace WebAppTests.Pages.Admin.Users;
 
 public class EditRolesTests
 {
-    private static readonly OfficeViewDto OfficeViewTest = new() { Id = Guid.Empty, Name = TextData.ValidName };
+    private static readonly OfficeViewDto OfficeViewTest = new(Guid.Empty, TextData.ValidName, true);
 
-    private static readonly StaffViewDto StaffViewTest = new()
-    {
-        Id = Guid.Empty.ToString(),
-        Email = TextData.ValidEmail,
-        GivenName = TextData.ValidName,
-        FamilyName = TextData.ValidName,
-        Office = OfficeViewTest,
-    };
+    private static readonly StaffViewDto StaffViewTest = new(
+        Guid.Empty.ToString(),
+        TextData.ValidName,
+        TextData.ValidName,
+        TextData.ValidEmail,
+        null,
+        OfficeViewTest,
+        true
+    );
 
     private static readonly List<EditRolesModel.RoleSetting> RoleSettingsTest = new()
     {

--- a/tests/WebAppTests/Pages/Admin/Users/EditTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Users/EditTests.cs
@@ -17,15 +17,19 @@ namespace WebAppTests.Pages.Admin.Users;
 
 public class EditTests
 {
-    private static readonly StaffViewDto StaffViewTest = new()
-    {
-        Id = Guid.Empty.ToString(),
-        Email = TextData.ValidEmail,
-        GivenName = TextData.ValidName,
-        FamilyName = TextData.ValidName,
-    };
+    private static readonly OfficeViewDto OfficeViewTest = new(Guid.Empty, TextData.ValidName, true);
 
-    private static readonly StaffUpdateDto StaffUpdateTest = new() { Id = Guid.Empty.ToString() };
+    private static readonly StaffViewDto StaffViewTest = new(
+        Guid.Empty.ToString(),
+        TextData.ValidName,
+        TextData.ValidName,
+        TextData.ValidEmail,
+        null,
+        OfficeViewTest,
+        true
+    );
+
+    private static readonly StaffUpdateDto StaffUpdateTest = new(Guid.Empty.ToString(), null, null, true);
 
     [Test]
     public async Task OnGet_PopulatesThePageModel()
@@ -36,8 +40,9 @@ public class EditTests
         var officeServiceMock = new Mock<IOfficeService>();
         officeServiceMock.Setup(l => l.GetActiveListItemsAsync(CancellationToken.None))
             .ReturnsAsync(new List<ListItem>());
-        var pageModel = new EditModel(staffServiceMock.Object, officeServiceMock.Object, Mock.Of<IValidator<StaffUpdateDto>>())
-        { TempData = WebAppTestsSetup.PageTempData() };
+        var pageModel = new EditModel(staffServiceMock.Object, officeServiceMock.Object,
+                Mock.Of<IValidator<StaffUpdateDto>>())
+            { TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await pageModel.OnGetAsync(StaffViewTest.Id);
 
@@ -54,8 +59,8 @@ public class EditTests
     public async Task OnGet_MissingIdReturnsNotFound()
     {
         var pageModel = new EditModel(Mock.Of<IStaffService>(),
-            Mock.Of<IOfficeService>(), Mock.Of<IValidator<StaffUpdateDto>>())
-        { TempData = WebAppTestsSetup.PageTempData() };
+                Mock.Of<IOfficeService>(), Mock.Of<IValidator<StaffUpdateDto>>())
+            { TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await pageModel.OnGetAsync(null);
 
@@ -73,8 +78,8 @@ public class EditTests
         staffServiceMock.Setup(l => l.FindAsync(It.IsAny<string>()))
             .ReturnsAsync((StaffViewDto?)null);
         var pageModel = new EditModel(staffServiceMock.Object,
-            Mock.Of<IOfficeService>(), Mock.Of<IValidator<StaffUpdateDto>>())
-        { TempData = WebAppTestsSetup.PageTempData() };
+                Mock.Of<IOfficeService>(), Mock.Of<IValidator<StaffUpdateDto>>())
+            { TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await pageModel.OnGetAsync(Guid.Empty.ToString());
 
@@ -94,7 +99,7 @@ public class EditTests
         validatorMock.Setup(l => l.ValidateAsync(It.IsAny<StaffUpdateDto>(), CancellationToken.None))
             .ReturnsAsync(new ValidationResult());
         var page = new EditModel(staffServiceMock.Object, Mock.Of<IOfficeService>(), validatorMock.Object)
-        { UpdateStaff = StaffUpdateTest, TempData = WebAppTestsSetup.PageTempData() };
+            { UpdateStaff = StaffUpdateTest, TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await page.OnPostAsync();
 
@@ -118,7 +123,7 @@ public class EditTests
         validatorMock.Setup(l => l.ValidateAsync(It.IsAny<StaffUpdateDto>(), CancellationToken.None))
             .ReturnsAsync(new ValidationResult());
         var page = new EditModel(staffServiceMock.Object, Mock.Of<IOfficeService>(), validatorMock.Object)
-        { UpdateStaff = StaffUpdateTest, TempData = WebAppTestsSetup.PageTempData() };
+            { UpdateStaff = StaffUpdateTest, TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await page.OnPostAsync();
 
@@ -140,7 +145,7 @@ public class EditTests
             .ReturnsAsync(new ValidationResult(validationFailures));
 
         var page = new EditModel(staffServiceMock.Object, officeServiceMock.Object, validatorMock.Object)
-        { UpdateStaff = StaffUpdateTest, TempData = WebAppTestsSetup.PageTempData() };
+            { UpdateStaff = StaffUpdateTest, TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await page.OnPostAsync();
 
@@ -164,7 +169,7 @@ public class EditTests
         validatorMock.Setup(l => l.ValidateAsync(It.IsAny<StaffUpdateDto>(), CancellationToken.None))
             .ReturnsAsync(new ValidationResult(validationFailures));
         var page = new EditModel(staffServiceMock.Object, Mock.Of<IOfficeService>(), validatorMock.Object)
-        { UpdateStaff = StaffUpdateTest, TempData = WebAppTestsSetup.PageTempData() };
+            { UpdateStaff = StaffUpdateTest, TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await page.OnPostAsync();
 

--- a/tests/WebAppTests/Pages/Admin/Users/IndexTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Users/IndexTests.cs
@@ -11,6 +11,8 @@ namespace WebAppTests.Pages.Admin.Users;
 
 public class IndexTests
 {
+    private static StaffSearchDto DefaultStaffSearch => new(SortBy.NameAsc, null, null, null, null, null);
+
     [Test]
     public async Task OnSearch_IfValidModel_ReturnsPage()
     {
@@ -30,7 +32,7 @@ public class IndexTests
             { TempData = WebAppTestsSetup.PageTempData() };
 
         // Act
-        var result = await page.OnGetSearchAsync(new StaffSearchDto());
+        var result = await page.OnGetSearchAsync(DefaultStaffSearch);
 
         // Assert
         using (new AssertionScope())
@@ -54,7 +56,7 @@ public class IndexTests
             { TempData = WebAppTestsSetup.PageTempData() };
         page.ModelState.AddModelError("Error", "Sample error description");
 
-        var result = await page.OnGetSearchAsync(new StaffSearchDto());
+        var result = await page.OnGetSearchAsync(DefaultStaffSearch);
 
         using (new AssertionScope())
         {


### PR DESCRIPTION
This PR changes all DTOs to be records instead of classes, records being good for one-way, immutable data flow with no additional behavior. 

See [this post](https://stackoverflow.com/a/64828780/212978) and its references for some justification. See also [this article](https://enterprisecraftsmanship.com/posts/csharp-records-value-objects/) for some of the ins and outs plus why records are not appropriate for value objects.