### PR TITLE
Fix some bugs with user account display and editing

### DIFF
--- a/src/AppServices/Staff/Dto/StaffUpdateDto.cs
+++ b/src/AppServices/Staff/Dto/StaffUpdateDto.cs
@@ -4,11 +4,17 @@ using System.ComponentModel.DataAnnotations;
 namespace Sbeap.AppServices.Staff.Dto;
 
 public record StaffUpdateDto
-(
-    string Id,
+{
+    public string Id { get; init; } = string.Empty;
+
     [StringLength(ApplicationUser.MaxPhoneLength,
         ErrorMessage = "The Phone Number must not be longer than {1} characters.")]
-    string? Phone,
-    [Required] [Display(Name = "Office")] Guid? OfficeId,
-    [Required] bool Active
-);
+    public string? Phone { get; init; }
+
+    [Required]
+    [Display(Name = "Office")]
+    public Guid? OfficeId { get; init; }
+
+    [Required]
+    public bool Active { get; set; }
+}

--- a/src/AppServices/Staff/Dto/StaffViewDto.cs
+++ b/src/AppServices/Staff/Dto/StaffViewDto.cs
@@ -5,18 +5,20 @@ using System.Text.Json.Serialization;
 
 namespace Sbeap.AppServices.Staff.Dto;
 
-public record StaffViewDto
-(
-    string Id,
-    string GivenName,
-    string FamilyName,
-    [Display(Name = "Email cannot be changed")]
-    string? Email,
-    string? Phone,
-    OfficeViewDto? Office,
-    bool Active
-) : IDtoHasNameProperty
+public record StaffViewDto : IDtoHasNameProperty
 {
+    public string Id { get; init; } = null!;
+    public string GivenName { get; init; } = null!;
+    public string FamilyName { get; init; } = null!;
+
+    [Display(Name = "Email cannot be changed")]
+    public string? Email { get; init; }
+
+    public string? Phone { get; init; }
+    public OfficeViewDto? Office { get; init; }
+    public bool Active { get; init; }
+
+    // Display properties
     [JsonIgnore]
     public string Name =>
         string.Join(" ", new[] { GivenName, FamilyName }.Where(s => !string.IsNullOrEmpty(s)));
@@ -25,5 +27,11 @@ public record StaffViewDto
     public string SortableFullName =>
         string.Join(", ", new[] { FamilyName, GivenName }.Where(s => !string.IsNullOrEmpty(s)));
 
-    public StaffUpdateDto AsUpdateDto() => new(Id, Phone, Office?.Id, Active);
+    public StaffUpdateDto AsUpdateDto() => new()
+    {
+        Id = Id,
+        Phone = Phone,
+        OfficeId = Office?.Id,
+        Active = Active,
+    };
 }

--- a/src/AppServices/Staff/StaffService.cs
+++ b/src/AppServices/Staff/StaffService.cs
@@ -64,12 +64,13 @@ public sealed class StaffService : IStaffService
 
     public async Task<IList<string>> GetRolesAsync(string id)
     {
-        ApplicationUser? user = await _userManager.FindByIdAsync(id);
+        var user = await _userManager.FindByIdAsync(id);
         if (user is null) return new List<string>();
         return await _userManager.GetRolesAsync(user);
     }
 
-    public async Task<IList<AppRole>> GetAppRolesAsync(string id) => AppRole.RolesAsAppRoles(await GetRolesAsync(id));
+    public async Task<IList<AppRole>> GetAppRolesAsync(string id) =>
+        AppRole.RolesAsAppRoles(await GetRolesAsync(id)).OrderBy(r => r.DisplayName).ToList();
 
     public async Task<IdentityResult> UpdateRolesAsync(string id, Dictionary<string, bool> roles)
     {

--- a/src/AppServices/Staff/StaffService.cs
+++ b/src/AppServices/Staff/StaffService.cs
@@ -104,7 +104,7 @@ public sealed class StaffService : IStaffService
             ?? throw new EntityNotFoundException(typeof(ApplicationUser), resource.Id);
 
         user.Phone = resource.Phone;
-        user.Office = resource.OfficeId is null ? null : await _officeRepository.FindAsync(resource.OfficeId.Value);
+        user.Office = resource.OfficeId is null ? null : await _officeRepository.GetAsync(resource.OfficeId.Value);
         user.Active = resource.Active;
 
         return await _userManager.UpdateAsync(user);

--- a/src/Domain/Identity/AppRole.cs
+++ b/src/Domain/Identity/AppRole.cs
@@ -42,7 +42,7 @@ public class AppRole
     /// </summary>
     /// <param name="roles">A list of role strings.</param>
     /// <returns>A list of AppRoles.</returns>
-    public static IList<AppRole> RolesAsAppRoles(IEnumerable<string> roles)
+    public static IEnumerable<AppRole> RolesAsAppRoles(IEnumerable<string> roles)
     {
         var appRoles = new List<AppRole>();
 

--- a/src/WebApp/Pages/Account/Edit.cshtml
+++ b/src/WebApp/Pages/Account/Edit.cshtml
@@ -28,11 +28,10 @@
             </div>
         </div>
         <div class="mt-3">
-            <input asp-for="UpdateStaff.Id" type="hidden" />
-            <input asp-for="UpdateStaff.Active" type="hidden" />
             <button type="submit" class="btn btn-primary col-sm-3 me-2">Update Info</button>
             <a asp-page="Index" class="btn btn-outline-secondary col-md-2">Cancel</a>
         </div>
         <div class="text-danger mt-3">* denotes a required field</div>
+        <input asp-for="UpdateStaff.Id" type="hidden" />
     </form>
 </div>

--- a/src/WebApp/Pages/Account/Edit.cshtml.cs
+++ b/src/WebApp/Pages/Account/Edit.cshtml.cs
@@ -43,7 +43,7 @@ public class EditModel : PageModel
     public async Task<IActionResult> OnGetAsync()
     {
         var staff = await _staffService.GetCurrentUserAsync();
-        if (staff is not { Active: true }) return Forbid();
+        if (!staff.Active) return Forbid();
 
         DisplayStaff = staff;
         UpdateStaff = DisplayStaff.AsUpdateDto();
@@ -55,9 +55,15 @@ public class EditModel : PageModel
     public async Task<IActionResult> OnPostAsync()
     {
         var staff = await _staffService.GetCurrentUserAsync();
-        if (staff.Id != UpdateStaff.Id || !UpdateStaff.Active)
-            return BadRequest();
+        
+        // Inactive staff cannot do anything here.
         if (!staff.Active) return Forbid();
+        
+        // Staff can only update self here.
+        if (staff.Id != UpdateStaff.Id) return BadRequest();
+
+        // User cannot deactivate self.
+        UpdateStaff.Active = true;
 
         await _validator.ApplyValidationAsync(UpdateStaff, ModelState);
 

--- a/src/WebApp/Pages/Admin/Users/Edit.cshtml
+++ b/src/WebApp/Pages/Admin/Users/Edit.cshtml
@@ -31,11 +31,11 @@
             @Html.EditorFor(e => e.UpdateStaff.Active, EditorTemplate.InputCheckbox)
         </div>
         <div class="mt-3">
-            <input asp-for="UpdateStaff.Id" type="hidden" />
             <button type="submit" class="btn btn-primary col-sm-3 me-2">Update Info</button>
             <a asp-page="Details" asp-route-id="@Model.UpdateStaff.Id" class="btn btn-outline-secondary col-md-2">Cancel</a>
         </div>
         <div class="text-danger mt-3">* denotes a required field</div>
+        <input asp-for="UpdateStaff.Id" type="hidden" />
     </form>
 </div>
 

--- a/tests/AppServicesTests/Staff/StaffDtoTests.cs
+++ b/tests/AppServicesTests/Staff/StaffDtoTests.cs
@@ -21,8 +21,12 @@ public class StaffDtoTests
         }
     }
 
-    private static StaffViewDto ValidStaffView =>
-        new(Guid.Empty.ToString(), string.Empty, string.Empty, null, null, null, true);
+    private static StaffViewDto ValidStaffView => new()
+    {
+        Id = Guid.Empty.ToString(),
+        FamilyName = string.Empty,
+        GivenName = string.Empty,
+    };
 
     [TestCase("abc", "def", "abc def")]
     [TestCase("abc", "", "abc")]

--- a/tests/WebAppTests/Pages/Account/EditTests.cs
+++ b/tests/WebAppTests/Pages/Account/EditTests.cs
@@ -17,22 +17,20 @@ namespace WebAppTests.Pages.Account;
 
 public class EditTests
 {
-    private static readonly StaffViewDto StaffViewTest = new(
-        Guid.Empty.ToString(),
-        TextData.ValidName,
-        TextData.ValidName,
-        TextData.ValidEmail,
-        null,
-        null,
-        true
-    );
+    private static readonly StaffViewDto StaffViewTest = new()
+    {
+        Id = Guid.Empty.ToString(),
+        FamilyName = TextData.ValidName,
+        GivenName = TextData.ValidName,
+        Email = TextData.ValidEmail,
+        Active = true,
+    };
 
-    private static readonly StaffUpdateDto StaffUpdateTest = new(
-        Guid.Empty.ToString(),
-        null,
-        null,
-        true
-    );
+    private static readonly StaffUpdateDto StaffUpdateTest = new()
+    {
+        Id = Guid.Empty.ToString(),
+        Active = true,
+    };
 
     [Test]
     public async Task OnGet_PopulatesThePageModel()

--- a/tests/WebAppTests/Pages/Admin/Users/DetailsTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Users/DetailsTests.cs
@@ -16,15 +16,14 @@ public class DetailsTests
     [Test]
     public async Task OnGet_PopulatesThePageModel()
     {
-        var staffView = new StaffViewDto(
-            Guid.Empty.ToString(),
-            TextData.ValidName,
-            TextData.ValidName,
-            TextData.ValidEmail,
-            null,
-            null,
-            true
-        );
+        var staffView = new StaffViewDto
+        {
+            Id = Guid.Empty.ToString(),
+            FamilyName = TextData.ValidName,
+            GivenName = TextData.ValidName,
+            Email = TextData.ValidEmail,
+            Active = true,
+        };
 
         var serviceMock = new Mock<IStaffService>();
         serviceMock.Setup(l => l.FindAsync(It.IsAny<string>()))

--- a/tests/WebAppTests/Pages/Admin/Users/EditRolesTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Users/EditRolesTests.cs
@@ -17,15 +17,15 @@ public class EditRolesTests
 {
     private static readonly OfficeViewDto OfficeViewTest = new(Guid.Empty, TextData.ValidName, true);
 
-    private static readonly StaffViewDto StaffViewTest = new(
-        Guid.Empty.ToString(),
-        TextData.ValidName,
-        TextData.ValidName,
-        TextData.ValidEmail,
-        null,
-        OfficeViewTest,
-        true
-    );
+    private static readonly StaffViewDto StaffViewTest = new()
+    {
+        Id = Guid.Empty.ToString(),
+        FamilyName = TextData.ValidName,
+        GivenName = TextData.ValidName,
+        Email = TextData.ValidEmail,
+        Office = OfficeViewTest,
+        Active = true,
+    };
 
     private static readonly List<EditRolesModel.RoleSetting> RoleSettingsTest = new()
     {

--- a/tests/WebAppTests/Pages/Admin/Users/EditTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Users/EditTests.cs
@@ -19,17 +19,21 @@ public class EditTests
 {
     private static readonly OfficeViewDto OfficeViewTest = new(Guid.Empty, TextData.ValidName, true);
 
-    private static readonly StaffViewDto StaffViewTest = new(
-        Guid.Empty.ToString(),
-        TextData.ValidName,
-        TextData.ValidName,
-        TextData.ValidEmail,
-        null,
-        OfficeViewTest,
-        true
-    );
+    private static readonly StaffViewDto StaffViewTest = new()
+    {
+        Id = Guid.Empty.ToString(),
+        FamilyName = TextData.ValidName,
+        GivenName = TextData.ValidName,
+        Email = TextData.ValidEmail,
+        Office = OfficeViewTest,
+        Active = true,
+    };
 
-    private static readonly StaffUpdateDto StaffUpdateTest = new(Guid.Empty.ToString(), null, null, true);
+    private static readonly StaffUpdateDto StaffUpdateTest = new()
+    {
+        Id = Guid.Empty.ToString(),
+        Active = true,
+    };
 
     [Test]
     public async Task OnGet_PopulatesThePageModel()


### PR DESCRIPTION
A few issues have accumulated, some due to recent changes that weren't thoroughly tested:

* Application roles were sorted on the user account pages by ID, which is unhelpful. I changed this to sort by the display name. (In future applications, I may end up implementing categories and explicit sort indexes.)
* Account editing was broken when using Entity Framework, because the office navigation property wasn't being tracked correctly.
* When switching DTOs from classes to records, I rewrote most of them to use the abbreviated constructor syntax. What I didn't realize at the time (and is never mentioned in any docs I've read) is that the "Display" attribute is completely ignored in that scenario. So I've had to revert several DTOs back to the more verbose syntax (but they are still records). (I should report this as a bug to Microsoft.)