### PR TITLE
Use authorization policies in web app instead of directly checking roles

### DIFF
--- a/src/AppServices/Permissions/Policies.cs
+++ b/src/AppServices/Permissions/Policies.cs
@@ -24,6 +24,7 @@ namespace Sbeap.AppServices.Permissions;
 public static class PolicyName
 {
     public const string AdminUser = nameof(AdminUser);
+    public const string LoggedIn = nameof(LoggedIn);
     public const string StaffUser = nameof(StaffUser);
     public const string SiteMaintainer = nameof(SiteMaintainer);
     public const string UserAdministrator = nameof(UserAdministrator);
@@ -35,6 +36,11 @@ public static class Policies
         new AuthorizationPolicyBuilder()
             .RequireAuthenticatedUser()
             .AddRequirements(new AdminUserRequirement())
+            .Build();
+
+    public static AuthorizationPolicy LoggedInPolicy() =>
+        new AuthorizationPolicyBuilder()
+            .RequireAuthenticatedUser()
             .Build();
 
     public static AuthorizationPolicy StaffUserPolicy() =>

--- a/src/AppServices/RegisterServices/AuthorizationPolicies.cs
+++ b/src/AppServices/RegisterServices/AuthorizationPolicies.cs
@@ -13,6 +13,7 @@ public static class AuthorizationPolicies
         services.AddAuthorization(opts =>
         {
             opts.AddPolicy(PolicyName.AdminUser, Policies.AdminUserPolicy());
+            opts.AddPolicy(PolicyName.LoggedIn, Policies.LoggedInPolicy());
             opts.AddPolicy(PolicyName.SiteMaintainer, Policies.SiteMaintainerPolicy());
             opts.AddPolicy(PolicyName.StaffUser, Policies.StaffUserPolicy());
             opts.AddPolicy(PolicyName.UserAdministrator, Policies.UserAdministratorPolicy());

--- a/src/WebApp/Pages/Error.cshtml
+++ b/src/WebApp/Pages/Error.cshtml
@@ -1,4 +1,7 @@
 ﻿@page "{statusCode:int?}"
+@inject IAuthorizationService AuthorizationService
+@using Microsoft.AspNetCore.Authorization
+@using Sbeap.AppServices.Permissions
 @model ErrorModel
 @switch (Model.Status)
 {
@@ -18,7 +21,7 @@
     }
 }
 
-@if (User.Identity?.IsAuthenticated ?? false)
+@if ((await AuthorizationService.AuthorizeAsync(User, PolicyName.LoggedIn)).Succeeded)
 {
     <p>
         If you need assistance related to this error, please

--- a/src/WebApp/Pages/Shared/_MenuPartial.cshtml
+++ b/src/WebApp/Pages/Shared/_MenuPartial.cshtml
@@ -1,7 +1,9 @@
-@using Sbeap.Domain.Identity
+@using Microsoft.AspNetCore.Authorization
+@using Sbeap.AppServices.Permissions
+@inject IAuthorizationService AuthorizationService
 @{
-    var isLoggedIn = User.Identity?.IsAuthenticated ?? false;
-    var isStaff = isLoggedIn && (User.IsInRole(RoleName.Staff) || User.IsInRole(RoleName.Admin));
+    var isLoggedIn = (await AuthorizationService.AuthorizeAsync(User, PolicyName.LoggedIn)).Succeeded;
+    var isStaff = (await AuthorizationService.AuthorizeAsync(User, PolicyName.StaffUser)).Succeeded;
 }
 <nav id="main-nav" class="navbar navbar-expand-sm navbar-dark bg-brand border-bottom shadow-sm mb-3 d-print-none">
     <div class="container">

--- a/src/WebApp/Pages/Shared/_RaygunScriptsPartial.cshtml
+++ b/src/WebApp/Pages/Shared/_RaygunScriptsPartial.cshtml
@@ -1,9 +1,12 @@
-﻿@using Sbeap.WebApp.Platform.Settings
-@inject IHttpContextAccessor ContextAccessor
+﻿@using Microsoft.AspNetCore.Authorization
+@using Sbeap.AppServices.Permissions
+@using Sbeap.WebApp.Platform.Settings
+@inject IAuthorizationService AuthorizationService
 @{
     var apiKey = ApplicationSettings.RaygunSettings.ApiKey;
     if (string.IsNullOrEmpty(apiKey)) return;
-    var identity = ContextAccessor.HttpContext?.User.Identity;
+    var isLoggedIn = (await AuthorizationService.AuthorizeAsync(User, PolicyName.LoggedIn)).Succeeded;
+    var identifier = isLoggedIn ? null : User.Identity?.Name;
     var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "unknown";
 }
 
@@ -18,9 +21,9 @@
     rg4js('apiKey', '@apiKey');
     rg4js('enableCrashReporting', true);
     rg4js('withTags', ['@environment']);
-    @if (identity?.IsAuthenticated == true)
+    @if (identifier is not null)
     {
-        @:rg4js('setUser', {isAnonymous: false, identifier: '@identity.Name'});
+        @:rg4js('setUser', {isAnonymous: false, identifier: '@identifier'});
     }
 </script>
 <environment names="Production"><script>rg4js('enablePulse', true);</script></environment>


### PR DESCRIPTION
The use of authorization policies is preferred to directly checking whether the user is authenticated or has certain roles, etc. because if authorization requirements change in the future, it is more reliable to update a single auth policy than to search for and update outdated code.