### PR TITLE
Implement an Active user policy

### DIFF
--- a/src/AppServices/Permissions/Policies.cs
+++ b/src/AppServices/Permissions/Policies.cs
@@ -23,6 +23,7 @@ namespace Sbeap.AppServices.Permissions;
 
 public static class PolicyName
 {
+    public const string ActiveUser = nameof(ActiveUser);
     public const string AdminUser = nameof(AdminUser);
     public const string LoggedIn = nameof(LoggedIn);
     public const string StaffUser = nameof(StaffUser);
@@ -32,9 +33,16 @@ public static class PolicyName
 
 public static class Policies
 {
+    public static AuthorizationPolicy ActiveUserPolicy() =>
+        new AuthorizationPolicyBuilder()
+            .RequireAuthenticatedUser()
+            .AddRequirements(new ActiveUserRequirement())
+            .Build();
+
     public static AuthorizationPolicy AdminUserPolicy() =>
         new AuthorizationPolicyBuilder()
             .RequireAuthenticatedUser()
+            .AddRequirements(new ActiveUserRequirement())
             .AddRequirements(new AdminUserRequirement())
             .Build();
 
@@ -43,21 +51,24 @@ public static class Policies
             .RequireAuthenticatedUser()
             .Build();
 
-    public static AuthorizationPolicy StaffUserPolicy() =>
-        new AuthorizationPolicyBuilder()
-            .RequireAuthenticatedUser()
-            .AddRequirements(new StaffUserRequirement())
-            .Build();
-
     public static AuthorizationPolicy SiteMaintainerPolicy() =>
         new AuthorizationPolicyBuilder()
             .RequireAuthenticatedUser()
+            .AddRequirements(new ActiveUserRequirement())
             .AddRequirements(new SiteMaintainerRequirement())
+            .Build();
+
+    public static AuthorizationPolicy StaffUserPolicy() =>
+        new AuthorizationPolicyBuilder()
+            .RequireAuthenticatedUser()
+            .AddRequirements(new ActiveUserRequirement())
+            .AddRequirements(new StaffUserRequirement())
             .Build();
 
     public static AuthorizationPolicy UserAdministratorPolicy() =>
         new AuthorizationPolicyBuilder()
             .RequireAuthenticatedUser()
+            .AddRequirements(new ActiveUserRequirement())
             .AddRequirements(new UserAdministratorRequirement())
             .Build();
 }

--- a/src/AppServices/Permissions/Policies.cs
+++ b/src/AppServices/Permissions/Policies.cs
@@ -21,51 +21,41 @@ namespace Sbeap.AppServices.Permissions;
 //
 #pragma warning restore S125
 
-public static class PolicyName
-{
-    public const string ActiveUser = nameof(ActiveUser);
-    public const string AdminUser = nameof(AdminUser);
-    public const string LoggedIn = nameof(LoggedIn);
-    public const string StaffUser = nameof(StaffUser);
-    public const string SiteMaintainer = nameof(SiteMaintainer);
-    public const string UserAdministrator = nameof(UserAdministrator);
-}
-
 public static class Policies
 {
-    public static AuthorizationPolicy ActiveUserPolicy() =>
+    public static AuthorizationPolicy ActiveUser() =>
         new AuthorizationPolicyBuilder()
             .RequireAuthenticatedUser()
             .AddRequirements(new ActiveUserRequirement())
             .Build();
 
-    public static AuthorizationPolicy AdminUserPolicy() =>
+    public static AuthorizationPolicy AdminUser() =>
         new AuthorizationPolicyBuilder()
             .RequireAuthenticatedUser()
             .AddRequirements(new ActiveUserRequirement())
             .AddRequirements(new AdminUserRequirement())
             .Build();
 
-    public static AuthorizationPolicy LoggedInPolicy() =>
+    public static AuthorizationPolicy LoggedIn() =>
         new AuthorizationPolicyBuilder()
             .RequireAuthenticatedUser()
             .Build();
 
-    public static AuthorizationPolicy SiteMaintainerPolicy() =>
+    public static AuthorizationPolicy SiteMaintainer() =>
         new AuthorizationPolicyBuilder()
             .RequireAuthenticatedUser()
             .AddRequirements(new ActiveUserRequirement())
             .AddRequirements(new SiteMaintainerRequirement())
             .Build();
 
-    public static AuthorizationPolicy StaffUserPolicy() =>
+    public static AuthorizationPolicy StaffUser() =>
         new AuthorizationPolicyBuilder()
             .RequireAuthenticatedUser()
             .AddRequirements(new ActiveUserRequirement())
             .AddRequirements(new StaffUserRequirement())
             .Build();
 
-    public static AuthorizationPolicy UserAdministratorPolicy() =>
+    public static AuthorizationPolicy UserAdministrator() =>
         new AuthorizationPolicyBuilder()
             .RequireAuthenticatedUser()
             .AddRequirements(new ActiveUserRequirement())

--- a/src/AppServices/Permissions/Requirements/ActiveUserRequirement.cs
+++ b/src/AppServices/Permissions/Requirements/ActiveUserRequirement.cs
@@ -1,16 +1,15 @@
 ﻿using Microsoft.AspNetCore.Authorization;
-using Sbeap.Domain.Identity;
 
 namespace Sbeap.AppServices.Permissions.Requirements;
 
-internal class SiteMaintainerRequirement :
-    AuthorizationHandler<SiteMaintainerRequirement>, IAuthorizationRequirement
+internal class ActiveUserRequirement :
+    AuthorizationHandler<ActiveUserRequirement>, IAuthorizationRequirement
 {
     protected override Task HandleRequirementAsync(
         AuthorizationHandlerContext context,
-        SiteMaintainerRequirement requirement)
+        ActiveUserRequirement requirement)
     {
-        if (context.User.IsInRole(RoleName.SiteMaintenance))
+        if (context.User.HasClaim(c => c is { Type: "ActiveUser", Value: "True" }))
             context.Succeed(requirement);
 
         return Task.FromResult(0);

--- a/src/AppServices/Permissions/Requirements/AdminUserRequirement.cs
+++ b/src/AppServices/Permissions/Requirements/AdminUserRequirement.cs
@@ -10,9 +10,6 @@ internal class AdminUserRequirement :
         AuthorizationHandlerContext context,
         AdminUserRequirement requirement)
     {
-        if (!(context.User.Identity?.IsAuthenticated ?? false))
-            return Task.FromResult(0);
-
         if (context.User.IsInRole(RoleName.Admin))
             context.Succeed(requirement);
 

--- a/src/AppServices/Permissions/Requirements/StaffUserRequirement.cs
+++ b/src/AppServices/Permissions/Requirements/StaffUserRequirement.cs
@@ -10,9 +10,6 @@ internal class StaffUserRequirement :
         AuthorizationHandlerContext context,
         StaffUserRequirement requirement)
     {
-        if (!(context.User.Identity?.IsAuthenticated ?? false))
-            return Task.FromResult(0);
-
         if (context.User.IsInRole(RoleName.Staff) || context.User.IsInRole(RoleName.Admin))
             context.Succeed(requirement);
 

--- a/src/AppServices/Permissions/Requirements/UserAdministratorRequirement.cs
+++ b/src/AppServices/Permissions/Requirements/UserAdministratorRequirement.cs
@@ -10,9 +10,6 @@ internal class UserAdministratorRequirement :
         AuthorizationHandlerContext context,
         UserAdministratorRequirement requirement)
     {
-        if (!(context.User.Identity?.IsAuthenticated ?? false))
-            return Task.FromResult(0);
-
         if (context.User.IsInRole(RoleName.UserAdmin))
             context.Succeed(requirement);
 

--- a/src/AppServices/RegisterServices/AuthorizationPolicies.cs
+++ b/src/AppServices/RegisterServices/AuthorizationPolicies.cs
@@ -12,12 +12,12 @@ public static class AuthorizationPolicies
     {
         services.AddAuthorization(opts =>
         {
-            opts.AddPolicy(PolicyName.ActiveUser, Policies.ActiveUserPolicy());
-            opts.AddPolicy(PolicyName.AdminUser, Policies.AdminUserPolicy());
-            opts.AddPolicy(PolicyName.LoggedIn, Policies.LoggedInPolicy());
-            opts.AddPolicy(PolicyName.SiteMaintainer, Policies.SiteMaintainerPolicy());
-            opts.AddPolicy(PolicyName.StaffUser, Policies.StaffUserPolicy());
-            opts.AddPolicy(PolicyName.UserAdministrator, Policies.UserAdministratorPolicy());
+            opts.AddPolicy(nameof(Policies.ActiveUser), Policies.ActiveUser());
+            opts.AddPolicy(nameof(Policies.AdminUser), Policies.AdminUser());
+            opts.AddPolicy(nameof(Policies.LoggedIn), Policies.LoggedIn());
+            opts.AddPolicy(nameof(Policies.SiteMaintainer), Policies.SiteMaintainer());
+            opts.AddPolicy(nameof(Policies.StaffUser), Policies.StaffUser());
+            opts.AddPolicy(nameof(Policies.UserAdministrator), Policies.UserAdministrator());
         });
 
         services.AddSingleton<IAuthorizationHandler>(_ => new ActionItemUpdatePermissionsHandler());

--- a/src/AppServices/RegisterServices/AuthorizationPolicies.cs
+++ b/src/AppServices/RegisterServices/AuthorizationPolicies.cs
@@ -12,6 +12,7 @@ public static class AuthorizationPolicies
     {
         services.AddAuthorization(opts =>
         {
+            opts.AddPolicy(PolicyName.ActiveUser, Policies.ActiveUserPolicy());
             opts.AddPolicy(PolicyName.AdminUser, Policies.AdminUserPolicy());
             opts.AddPolicy(PolicyName.LoggedIn, Policies.LoggedInPolicy());
             opts.AddPolicy(PolicyName.SiteMaintainer, Policies.SiteMaintainerPolicy());

--- a/src/WebApp/Pages/Account/Edit.cshtml.cs
+++ b/src/WebApp/Pages/Account/Edit.cshtml.cs
@@ -13,7 +13,7 @@ using Sbeap.WebApp.Platform.PageModelHelpers;
 
 namespace Sbeap.WebApp.Pages.Account;
 
-[Authorize(Policy = PolicyName.ActiveUser)]
+[Authorize(Policy = nameof(Policies.ActiveUser))]
 public class EditModel : PageModel
 {
     // Constructor
@@ -56,10 +56,10 @@ public class EditModel : PageModel
     public async Task<IActionResult> OnPostAsync()
     {
         var staff = await _staffService.GetCurrentUserAsync();
-        
+
         // Inactive staff cannot do anything here.
         if (!staff.Active) return Forbid();
-        
+
         // Staff can only update self here.
         if (staff.Id != UpdateStaff.Id) return BadRequest();
 

--- a/src/WebApp/Pages/Account/Edit.cshtml.cs
+++ b/src/WebApp/Pages/Account/Edit.cshtml.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Sbeap.AppServices.Offices;
+using Sbeap.AppServices.Permissions;
 using Sbeap.AppServices.Staff;
 using Sbeap.AppServices.Staff.Dto;
 using Sbeap.WebApp.Models;
@@ -12,7 +13,7 @@ using Sbeap.WebApp.Platform.PageModelHelpers;
 
 namespace Sbeap.WebApp.Pages.Account;
 
-[Authorize]
+[Authorize(Policy = PolicyName.ActiveUser)]
 public class EditModel : PageModel
 {
     // Constructor

--- a/src/WebApp/Pages/Account/Index.cshtml
+++ b/src/WebApp/Pages/Account/Index.cshtml
@@ -8,7 +8,13 @@
 <h1>@ViewData["Title"]</h1>
 <hr />
 
-<h2>@Html.DisplayFor(m => m.DisplayStaff, DisplayTemplate.NameOrNone)</h2>
+<h2>
+    @if (!Model.DisplayStaff.Active)
+    {
+        <em class="text-warning">Inactive:</em>
+    }
+    @Html.DisplayFor(m => m.DisplayStaff, DisplayTemplate.NameOrNone)
+</h2>
 
 <dl class="row">
     <dt class="col-sm-3">Email</dt>
@@ -22,7 +28,10 @@
 </dl>
 
 <div class="mb-3">
-    <a asp-page="Edit" class="btn btn-outline-primary me-2">Edit Profile</a>
+    @if (Model.DisplayStaff.Active)
+    {
+        <a asp-page="Edit" class="btn btn-outline-primary me-2">Edit Profile</a>
+    }
     <form class="form-inline d-inline-block" asp-page="Logout" method="post">
         <button type="submit" class="btn btn-danger">Sign out</button>
     </form>

--- a/src/WebApp/Pages/Account/Index.cshtml.cs
+++ b/src/WebApp/Pages/Account/Index.cshtml.cs
@@ -1,13 +1,14 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Sbeap.AppServices.Permissions;
 using Sbeap.AppServices.Staff;
 using Sbeap.AppServices.Staff.Dto;
 using Sbeap.Domain.Identity;
 
 namespace Sbeap.WebApp.Pages.Account;
 
-[Authorize]
+[Authorize(Policy = PolicyName.LoggedIn)]
 public class IndexModel : PageModel
 {
     public StaffViewDto DisplayStaff { get; private set; } = default!;
@@ -16,12 +17,8 @@ public class IndexModel : PageModel
 
     public async Task<IActionResult> OnGetAsync([FromServices] IStaffService staffService)
     {
-        var staff = await staffService.GetCurrentUserAsync();
-        if (staff is not { Active: true }) return Forbid();
-
-        DisplayStaff = staff;
+        DisplayStaff = await staffService.GetCurrentUserAsync();
         Roles = await staffService.GetAppRolesAsync(DisplayStaff.Id);
-
         return Page();
     }
 }

--- a/src/WebApp/Pages/Account/Index.cshtml.cs
+++ b/src/WebApp/Pages/Account/Index.cshtml.cs
@@ -8,7 +8,7 @@ using Sbeap.Domain.Identity;
 
 namespace Sbeap.WebApp.Pages.Account;
 
-[Authorize(Policy = PolicyName.LoggedIn)]
+[Authorize(Policy = nameof(Policies.LoggedIn))]
 public class IndexModel : PageModel
 {
     public StaffViewDto DisplayStaff { get; private set; } = default!;

--- a/src/WebApp/Pages/Admin/Maintenance/ActionItemType/Add.cshtml.cs
+++ b/src/WebApp/Pages/Admin/Maintenance/ActionItemType/Add.cshtml.cs
@@ -9,7 +9,7 @@ using Sbeap.WebApp.Platform.PageModelHelpers;
 
 namespace Sbeap.WebApp.Pages.Admin.Maintenance.ActionItemType;
 
-[Authorize(Policy = PolicyName.SiteMaintainer)]
+[Authorize(Policy = nameof(Policies.SiteMaintainer))]
 public class AddModel : PageModel
 {
     // Constructor

--- a/src/WebApp/Pages/Admin/Maintenance/ActionItemType/Edit.cshtml.cs
+++ b/src/WebApp/Pages/Admin/Maintenance/ActionItemType/Edit.cshtml.cs
@@ -9,7 +9,7 @@ using Sbeap.WebApp.Platform.PageModelHelpers;
 
 namespace Sbeap.WebApp.Pages.Admin.Maintenance.ActionItemType;
 
-[Authorize(Policy = PolicyName.SiteMaintainer)]
+[Authorize(Policy = nameof(Policies.SiteMaintainer))]
 public class EditModel : PageModel
 {
     // Constructor

--- a/src/WebApp/Pages/Admin/Maintenance/ActionItemType/Index.cshtml.cs
+++ b/src/WebApp/Pages/Admin/Maintenance/ActionItemType/Index.cshtml.cs
@@ -6,7 +6,7 @@ using Sbeap.AppServices.Permissions;
 
 namespace Sbeap.WebApp.Pages.Admin.Maintenance.ActionItemType;
 
-[Authorize(Policy = PolicyName.StaffUser)]
+[Authorize(Policy = nameof(Policies.StaffUser))]
 public class IndexModel : PageModel
 {
     public IReadOnlyList<ActionItemTypeViewDto> Items { get; private set; } = default!;
@@ -23,6 +23,6 @@ public class IndexModel : PageModel
         [FromServices] IAuthorizationService authorization)
     {
         Items = await service.GetListAsync();
-        IsSiteMaintainer = (await authorization.AuthorizeAsync(User, PolicyName.SiteMaintainer)).Succeeded;
+        IsSiteMaintainer = (await authorization.AuthorizeAsync(User, nameof(Policies.SiteMaintainer))).Succeeded;
     }
 }

--- a/src/WebApp/Pages/Admin/Maintenance/Agency/Add.cshtml.cs
+++ b/src/WebApp/Pages/Admin/Maintenance/Agency/Add.cshtml.cs
@@ -9,7 +9,7 @@ using Sbeap.WebApp.Platform.PageModelHelpers;
 
 namespace Sbeap.WebApp.Pages.Admin.Maintenance.Agency;
 
-[Authorize(Policy = PolicyName.SiteMaintainer)]
+[Authorize(Policy = nameof(Policies.SiteMaintainer))]
 public class AddModel : PageModel
 {
     // Constructor

--- a/src/WebApp/Pages/Admin/Maintenance/Agency/Edit.cshtml.cs
+++ b/src/WebApp/Pages/Admin/Maintenance/Agency/Edit.cshtml.cs
@@ -9,7 +9,7 @@ using Sbeap.WebApp.Platform.PageModelHelpers;
 
 namespace Sbeap.WebApp.Pages.Admin.Maintenance.Agency;
 
-[Authorize(Policy = PolicyName.SiteMaintainer)]
+[Authorize(Policy = nameof(Policies.SiteMaintainer))]
 public class EditModel : PageModel
 {
     // Constructor

--- a/src/WebApp/Pages/Admin/Maintenance/Agency/Index.cshtml.cs
+++ b/src/WebApp/Pages/Admin/Maintenance/Agency/Index.cshtml.cs
@@ -6,7 +6,7 @@ using Sbeap.AppServices.Permissions;
 
 namespace Sbeap.WebApp.Pages.Admin.Maintenance.Agency;
 
-[Authorize(Policy = PolicyName.StaffUser)]
+[Authorize(Policy = nameof(Policies.StaffUser))]
 public class IndexModel : PageModel
 {
     public IReadOnlyList<AgencyViewDto> Items { get; private set; } = default!;
@@ -23,6 +23,6 @@ public class IndexModel : PageModel
         [FromServices] IAuthorizationService authorization)
     {
         Items = await service.GetListAsync();
-        IsSiteMaintainer = (await authorization.AuthorizeAsync(User, PolicyName.SiteMaintainer)).Succeeded;
+        IsSiteMaintainer = (await authorization.AuthorizeAsync(User, nameof(Policies.SiteMaintainer))).Succeeded;
     }
 }

--- a/src/WebApp/Pages/Admin/Maintenance/Index.cshtml.cs
+++ b/src/WebApp/Pages/Admin/Maintenance/Index.cshtml.cs
@@ -4,7 +4,7 @@ using Sbeap.AppServices.Permissions;
 
 namespace Sbeap.WebApp.Pages.Admin.Maintenance;
 
-[Authorize(Policy = PolicyName.StaffUser)]
+[Authorize(Policy = nameof(Policies.StaffUser))]
 public class IndexModel : PageModel
 {
     public void OnGet()

--- a/src/WebApp/Pages/Admin/Maintenance/Offices/Add.cshtml.cs
+++ b/src/WebApp/Pages/Admin/Maintenance/Offices/Add.cshtml.cs
@@ -9,7 +9,7 @@ using Sbeap.WebApp.Platform.PageModelHelpers;
 
 namespace Sbeap.WebApp.Pages.Admin.Maintenance.Offices;
 
-[Authorize(Policy = PolicyName.SiteMaintainer)]
+[Authorize(Policy = nameof(Policies.SiteMaintainer))]
 public class AddModel : PageModel
 {
     // Constructor

--- a/src/WebApp/Pages/Admin/Maintenance/Offices/Edit.cshtml.cs
+++ b/src/WebApp/Pages/Admin/Maintenance/Offices/Edit.cshtml.cs
@@ -9,7 +9,7 @@ using Sbeap.WebApp.Platform.PageModelHelpers;
 
 namespace Sbeap.WebApp.Pages.Admin.Maintenance.Offices;
 
-[Authorize(Policy = PolicyName.SiteMaintainer)]
+[Authorize(Policy = nameof(Policies.SiteMaintainer))]
 public class EditModel : PageModel
 {
     // Constructor

--- a/src/WebApp/Pages/Admin/Maintenance/Offices/Index.cshtml.cs
+++ b/src/WebApp/Pages/Admin/Maintenance/Offices/Index.cshtml.cs
@@ -6,7 +6,7 @@ using Sbeap.AppServices.Permissions;
 
 namespace Sbeap.WebApp.Pages.Admin.Maintenance.Offices;
 
-[Authorize(Policy = PolicyName.StaffUser)]
+[Authorize(Policy = nameof(Policies.StaffUser))]
 public class IndexModel : PageModel
 {
     public IReadOnlyList<OfficeViewDto> Items { get; private set; } = default!;
@@ -21,6 +21,6 @@ public class IndexModel : PageModel
         [FromServices] IAuthorizationService authorization)
     {
         Items = await service.GetListAsync();
-        IsSiteMaintainer = (await authorization.AuthorizeAsync(User, PolicyName.SiteMaintainer)).Succeeded;
+        IsSiteMaintainer = (await authorization.AuthorizeAsync(User, nameof(Policies.SiteMaintainer))).Succeeded;
     }
 }

--- a/src/WebApp/Pages/Admin/Users/Details.cshtml.cs
+++ b/src/WebApp/Pages/Admin/Users/Details.cshtml.cs
@@ -8,7 +8,7 @@ using Sbeap.Domain.Identity;
 
 namespace Sbeap.WebApp.Pages.Admin.Users;
 
-[Authorize]
+[Authorize(Policy = PolicyName.ActiveUser)]
 public class DetailsModel : PageModel
 {
     public StaffViewDto DisplayStaff { get; private set; } = default!;

--- a/src/WebApp/Pages/Admin/Users/Details.cshtml.cs
+++ b/src/WebApp/Pages/Admin/Users/Details.cshtml.cs
@@ -8,7 +8,7 @@ using Sbeap.Domain.Identity;
 
 namespace Sbeap.WebApp.Pages.Admin.Users;
 
-[Authorize(Policy = PolicyName.ActiveUser)]
+[Authorize(Policy = nameof(Policies.ActiveUser))]
 public class DetailsModel : PageModel
 {
     public StaffViewDto DisplayStaff { get; private set; } = default!;
@@ -27,7 +27,7 @@ public class DetailsModel : PageModel
 
         DisplayStaff = staff;
         Roles = await staffService.GetAppRolesAsync(DisplayStaff.Id);
-        IsUserAdministrator = (await authorization.AuthorizeAsync(User, PolicyName.UserAdministrator)).Succeeded;
+        IsUserAdministrator = (await authorization.AuthorizeAsync(User, nameof(Policies.UserAdministrator))).Succeeded;
 
         return Page();
     }

--- a/src/WebApp/Pages/Admin/Users/Edit.cshtml.cs
+++ b/src/WebApp/Pages/Admin/Users/Edit.cshtml.cs
@@ -13,7 +13,7 @@ using Sbeap.WebApp.Platform.PageModelHelpers;
 
 namespace Sbeap.WebApp.Pages.Admin.Users;
 
-[Authorize(Policy = PolicyName.UserAdministrator)]
+[Authorize(Policy = nameof(Policies.UserAdministrator))]
 public class EditModel : PageModel
 {
     // Constructor

--- a/src/WebApp/Pages/Admin/Users/EditRoles.cshtml.cs
+++ b/src/WebApp/Pages/Admin/Users/EditRoles.cshtml.cs
@@ -10,7 +10,7 @@ using Sbeap.WebApp.Platform.PageModelHelpers;
 
 namespace Sbeap.WebApp.Pages.Admin.Users;
 
-[Authorize(Policy = PolicyName.UserAdministrator)]
+[Authorize(Policy = nameof(Policies.UserAdministrator))]
 public class EditRolesModel : PageModel
 {
     // Constructor

--- a/src/WebApp/Pages/Admin/Users/Index.cshtml.cs
+++ b/src/WebApp/Pages/Admin/Users/Index.cshtml.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Sbeap.AppServices.Offices;
+using Sbeap.AppServices.Permissions;
 using Sbeap.AppServices.Staff;
 using Sbeap.AppServices.Staff.Dto;
 using Sbeap.Domain.Identity;
@@ -13,7 +14,7 @@ using Sbeap.WebApp.Platform.Constants;
 
 namespace Sbeap.WebApp.Pages.Admin.Users;
 
-[Authorize]
+[Authorize(Policy = PolicyName.ActiveUser)]
 public class IndexModel : PageModel
 {
     // Constructor

--- a/src/WebApp/Pages/Admin/Users/Index.cshtml.cs
+++ b/src/WebApp/Pages/Admin/Users/Index.cshtml.cs
@@ -14,7 +14,7 @@ using Sbeap.WebApp.Platform.Constants;
 
 namespace Sbeap.WebApp.Pages.Admin.Users;
 
-[Authorize(Policy = PolicyName.ActiveUser)]
+[Authorize(Policy = nameof(Policies.ActiveUser))]
 public class IndexModel : PageModel
 {
     // Constructor

--- a/src/WebApp/Pages/Cases/Delete.cshtml.cs
+++ b/src/WebApp/Pages/Cases/Delete.cshtml.cs
@@ -11,7 +11,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Sbeap.WebApp.Pages.Cases;
 
-[Authorize(Policy = PolicyName.AdminUser)]
+[Authorize(Policy = nameof(Policies.AdminUser))]
 public class DeleteModel : PageModel
 {
     // Constructor

--- a/src/WebApp/Pages/Cases/DeleteAction.cshtml.cs
+++ b/src/WebApp/Pages/Cases/DeleteAction.cshtml.cs
@@ -9,7 +9,7 @@ using Sbeap.WebApp.Platform.PageModelHelpers;
 
 namespace Sbeap.WebApp.Pages.Cases;
 
-[Authorize(Policy = PolicyName.AdminUser)]
+[Authorize(Policy = nameof(Policies.AdminUser))]
 public class DeleteActionModel : PageModel
 {
     // Constructor
@@ -71,5 +71,5 @@ public class DeleteActionModel : PageModel
     }
 
     private async Task<bool> UserCanManageDeletionsAsync() =>
-        (await _authorization.AuthorizeAsync(User, PolicyName.AdminUser)).Succeeded;
+        (await _authorization.AuthorizeAsync(User, nameof(Policies.AdminUser))).Succeeded;
 }

--- a/src/WebApp/Pages/Cases/Details.cshtml.cs
+++ b/src/WebApp/Pages/Cases/Details.cshtml.cs
@@ -13,7 +13,7 @@ using Sbeap.WebApp.Platform.PageModelHelpers;
 
 namespace Sbeap.WebApp.Pages.Cases;
 
-[Authorize(Policy = PolicyName.StaffUser)]
+[Authorize(Policy = nameof(Policies.StaffUser))]
 public class DetailsModel : PageModel
 {
     // Constructor

--- a/src/WebApp/Pages/Cases/Edit.cshtml.cs
+++ b/src/WebApp/Pages/Cases/Edit.cshtml.cs
@@ -14,7 +14,7 @@ using Sbeap.WebApp.Platform.PageModelHelpers;
 
 namespace Sbeap.WebApp.Pages.Cases;
 
-[Authorize(Policy = PolicyName.StaffUser)]
+[Authorize(Policy = nameof(Policies.StaffUser))]
 public class EditModel : PageModel
 {
     private readonly ICaseworkService _service;

--- a/src/WebApp/Pages/Cases/EditAction.cshtml.cs
+++ b/src/WebApp/Pages/Cases/EditAction.cshtml.cs
@@ -13,7 +13,7 @@ using Sbeap.WebApp.Platform.PageModelHelpers;
 
 namespace Sbeap.WebApp.Pages.Cases;
 
-[Authorize(Policy = PolicyName.StaffUser)]
+[Authorize(Policy = nameof(Policies.StaffUser))]
 public class EditActionModel : PageModel
 {
     // Constructor

--- a/src/WebApp/Pages/Cases/Index.cshtml.cs
+++ b/src/WebApp/Pages/Cases/Index.cshtml.cs
@@ -13,7 +13,7 @@ using Sbeap.WebApp.Platform.Constants;
 
 namespace Sbeap.WebApp.Pages.Cases;
 
-[Authorize(Policy = PolicyName.StaffUser)]
+[Authorize(Policy = nameof(Policies.StaffUser))]
 public class IndexModel : PageModel
 {
     // Constructor
@@ -68,5 +68,5 @@ public class IndexModel : PageModel
         AgencySelectList = (await _agencyService.GetListItemsAsync(false)).ToSelectList();
 
     private async Task<bool> UserCanManageDeletionsAsync() =>
-        (await _authorization.AuthorizeAsync(User, PolicyName.AdminUser)).Succeeded;
+        (await _authorization.AuthorizeAsync(User, nameof(Policies.AdminUser))).Succeeded;
 }

--- a/src/WebApp/Pages/Cases/Restore.cshtml.cs
+++ b/src/WebApp/Pages/Cases/Restore.cshtml.cs
@@ -10,7 +10,7 @@ using Sbeap.WebApp.Platform.PageModelHelpers;
 
 namespace Sbeap.WebApp.Pages.Cases;
 
-[Authorize(Policy = PolicyName.AdminUser)]
+[Authorize(Policy = nameof(Policies.AdminUser))]
 public class RestoreModel : PageModel
 {
     // Constructor

--- a/src/WebApp/Pages/Customers/Add.cshtml.cs
+++ b/src/WebApp/Pages/Customers/Add.cshtml.cs
@@ -12,7 +12,7 @@ using Sbeap.WebApp.Platform.PageModelHelpers;
 
 namespace Sbeap.WebApp.Pages.Customers;
 
-[Authorize(Policy = PolicyName.StaffUser)]
+[Authorize(Policy = nameof(Policies.StaffUser))]
 public class AddModel : PageModel
 {
     // Constructor

--- a/src/WebApp/Pages/Customers/AddContact.cshtml.cs
+++ b/src/WebApp/Pages/Customers/AddContact.cshtml.cs
@@ -12,7 +12,7 @@ using Sbeap.WebApp.Platform.PageModelHelpers;
 
 namespace Sbeap.WebApp.Pages.Customers;
 
-[Authorize(Policy = PolicyName.StaffUser)]
+[Authorize(Policy = nameof(Policies.StaffUser))]
 public class AddContactModel : PageModel
 {
     // Constructor
@@ -78,5 +78,5 @@ public class AddContactModel : PageModel
     }
 
     private async Task<bool> UserCanManageDeletionsAsync() =>
-        (await _authorization.AuthorizeAsync(User, PolicyName.AdminUser)).Succeeded;
+        (await _authorization.AuthorizeAsync(User, nameof(Policies.AdminUser))).Succeeded;
 }

--- a/src/WebApp/Pages/Customers/Delete.cshtml.cs
+++ b/src/WebApp/Pages/Customers/Delete.cshtml.cs
@@ -11,7 +11,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Sbeap.WebApp.Pages.Customers;
 
-[Authorize(Policy = PolicyName.AdminUser)]
+[Authorize(Policy = nameof(Policies.AdminUser))]
 public class DeleteModel : PageModel
 {
     // Constructor

--- a/src/WebApp/Pages/Customers/DeleteContact.cshtml.cs
+++ b/src/WebApp/Pages/Customers/DeleteContact.cshtml.cs
@@ -9,7 +9,7 @@ using Sbeap.WebApp.Platform.PageModelHelpers;
 
 namespace Sbeap.WebApp.Pages.Customers;
 
-[Authorize(Policy = PolicyName.AdminUser)]
+[Authorize(Policy = nameof(Policies.AdminUser))]
 public class DeleteContactModel : PageModel
 {
     // Constructor
@@ -68,5 +68,5 @@ public class DeleteContactModel : PageModel
     }
 
     private async Task<bool> UserCanManageDeletionsAsync() =>
-        (await _authorization.AuthorizeAsync(User, PolicyName.AdminUser)).Succeeded;
+        (await _authorization.AuthorizeAsync(User, nameof(Policies.AdminUser))).Succeeded;
 }

--- a/src/WebApp/Pages/Customers/Details.cshtml.cs
+++ b/src/WebApp/Pages/Customers/Details.cshtml.cs
@@ -13,7 +13,7 @@ using Sbeap.WebApp.Platform.PageModelHelpers;
 
 namespace Sbeap.WebApp.Pages.Customers;
 
-[Authorize(Policy = PolicyName.StaffUser)]
+[Authorize(Policy = nameof(Policies.StaffUser))]
 public class DetailsModel : PageModel
 {
     // Constructor
@@ -87,5 +87,5 @@ public class DetailsModel : PageModel
         UserCan[operation] = (await _authorization.AuthorizeAsync(User, Item, operation)).Succeeded;
 
     private async Task<bool> ShowDeletedCasesAsync() =>
-        (await _authorization.AuthorizeAsync(User, PolicyName.AdminUser)).Succeeded;
+        (await _authorization.AuthorizeAsync(User, nameof(Policies.AdminUser))).Succeeded;
 }

--- a/src/WebApp/Pages/Customers/Edit.cshtml.cs
+++ b/src/WebApp/Pages/Customers/Edit.cshtml.cs
@@ -13,7 +13,7 @@ using Sbeap.WebApp.Platform.PageModelHelpers;
 
 namespace Sbeap.WebApp.Pages.Customers;
 
-[Authorize(Policy = PolicyName.StaffUser)]
+[Authorize(Policy = nameof(Policies.StaffUser))]
 public class EditModel : PageModel
 {
     // Constructor

--- a/src/WebApp/Pages/Customers/EditContact.cshtml.cs
+++ b/src/WebApp/Pages/Customers/EditContact.cshtml.cs
@@ -13,7 +13,7 @@ using Sbeap.WebApp.Platform.PageModelHelpers;
 
 namespace Sbeap.WebApp.Pages.Customers;
 
-[Authorize(Policy = PolicyName.StaffUser)]
+[Authorize(Policy = nameof(Policies.StaffUser))]
 public class EditContactModel : PageModel
 {
     // Constructor

--- a/src/WebApp/Pages/Customers/Index.cshtml.cs
+++ b/src/WebApp/Pages/Customers/Index.cshtml.cs
@@ -12,7 +12,7 @@ using Sbeap.WebApp.Platform.Constants;
 
 namespace Sbeap.WebApp.Pages.Customers;
 
-[Authorize(Policy = PolicyName.StaffUser)]
+[Authorize(Policy = nameof(Policies.StaffUser))]
 public class IndexModel : PageModel
 {
     // Constructor
@@ -59,5 +59,5 @@ public class IndexModel : PageModel
     }
 
     private async Task<bool> UserCanManageDeletionsAsync() =>
-        (await _authorization.AuthorizeAsync(User, PolicyName.AdminUser)).Succeeded;
+        (await _authorization.AuthorizeAsync(User, nameof(Policies.AdminUser))).Succeeded;
 }

--- a/src/WebApp/Pages/Customers/Restore.cshtml.cs
+++ b/src/WebApp/Pages/Customers/Restore.cshtml.cs
@@ -10,7 +10,7 @@ using Sbeap.WebApp.Platform.PageModelHelpers;
 
 namespace Sbeap.WebApp.Pages.Customers;
 
-[Authorize(Policy = PolicyName.AdminUser)]
+[Authorize(Policy = nameof(Policies.AdminUser))]
 public class RestoreModel : PageModel
 {
     // Constructor

--- a/src/WebApp/Pages/Error.cshtml
+++ b/src/WebApp/Pages/Error.cshtml
@@ -21,7 +21,7 @@
     }
 }
 
-@if ((await AuthorizationService.AuthorizeAsync(User, PolicyName.ActiveUser)).Succeeded)
+@if ((await AuthorizationService.AuthorizeAsync(User, nameof(Policies.ActiveUser))).Succeeded)
 {
     <p>
         If you need assistance related to this error, please

--- a/src/WebApp/Pages/Error.cshtml
+++ b/src/WebApp/Pages/Error.cshtml
@@ -21,7 +21,7 @@
     }
 }
 
-@if ((await AuthorizationService.AuthorizeAsync(User, PolicyName.LoggedIn)).Succeeded)
+@if ((await AuthorizationService.AuthorizeAsync(User, PolicyName.ActiveUser)).Succeeded)
 {
     <p>
         If you need assistance related to this error, please

--- a/src/WebApp/Pages/Index.cshtml.cs
+++ b/src/WebApp/Pages/Index.cshtml.cs
@@ -51,5 +51,5 @@ public class IndexModel : PageModel
     }
 
     private async Task<bool> UseDashboardAsync() =>
-        (await _authorization.AuthorizeAsync(User, PolicyName.StaffUser)).Succeeded;
+        (await _authorization.AuthorizeAsync(User, nameof(Policies.StaffUser))).Succeeded;
 }

--- a/src/WebApp/Pages/Shared/_MenuPartial.cshtml
+++ b/src/WebApp/Pages/Shared/_MenuPartial.cshtml
@@ -2,6 +2,7 @@
 @using Sbeap.AppServices.Permissions
 @inject IAuthorizationService AuthorizationService
 @{
+    var isActive = (await AuthorizationService.AuthorizeAsync(User, PolicyName.ActiveUser)).Succeeded;
     var isLoggedIn = (await AuthorizationService.AuthorizeAsync(User, PolicyName.LoggedIn)).Succeeded;
     var isStaff = (await AuthorizationService.AuthorizeAsync(User, PolicyName.StaffUser)).Succeeded;
 }
@@ -30,7 +31,7 @@
                 }
             </ul>
 
-            @if (isLoggedIn)
+            @if (isActive)
             {
                 <ul class="navbar-nav">
                     <li class="nav-item dropdown text-white">

--- a/src/WebApp/Pages/Shared/_MenuPartial.cshtml
+++ b/src/WebApp/Pages/Shared/_MenuPartial.cshtml
@@ -2,9 +2,9 @@
 @using Sbeap.AppServices.Permissions
 @inject IAuthorizationService AuthorizationService
 @{
-    var isActive = (await AuthorizationService.AuthorizeAsync(User, PolicyName.ActiveUser)).Succeeded;
-    var isLoggedIn = (await AuthorizationService.AuthorizeAsync(User, PolicyName.LoggedIn)).Succeeded;
-    var isStaff = (await AuthorizationService.AuthorizeAsync(User, PolicyName.StaffUser)).Succeeded;
+    var isActive = (await AuthorizationService.AuthorizeAsync(User, nameof(Policies.ActiveUser))).Succeeded;
+    var isLoggedIn = (await AuthorizationService.AuthorizeAsync(User, nameof(Policies.LoggedIn))).Succeeded;
+    var isStaff = (await AuthorizationService.AuthorizeAsync(User, nameof(Policies.StaffUser))).Succeeded;
 }
 <nav id="main-nav" class="navbar navbar-expand-sm navbar-dark bg-brand border-bottom shadow-sm mb-3 d-print-none">
     <div class="container">

--- a/src/WebApp/Pages/Shared/_RaygunScriptsPartial.cshtml
+++ b/src/WebApp/Pages/Shared/_RaygunScriptsPartial.cshtml
@@ -5,8 +5,7 @@
 @{
     var apiKey = ApplicationSettings.RaygunSettings.ApiKey;
     if (string.IsNullOrEmpty(apiKey)) return;
-    var isLoggedIn = (await AuthorizationService.AuthorizeAsync(User, PolicyName.LoggedIn)).Succeeded;
-    var identifier = isLoggedIn ? null : User.Identity?.Name;
+    var identifier = (await AuthorizationService.AuthorizeAsync(User, PolicyName.ActiveUser)).Succeeded ? null : User.Identity?.Name;
     var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "unknown";
 }
 

--- a/src/WebApp/Pages/Shared/_RaygunScriptsPartial.cshtml
+++ b/src/WebApp/Pages/Shared/_RaygunScriptsPartial.cshtml
@@ -5,7 +5,7 @@
 @{
     var apiKey = ApplicationSettings.RaygunSettings.ApiKey;
     if (string.IsNullOrEmpty(apiKey)) return;
-    var identifier = (await AuthorizationService.AuthorizeAsync(User, PolicyName.ActiveUser)).Succeeded ? null : User.Identity?.Name;
+    var identifier = (await AuthorizationService.AuthorizeAsync(User, nameof(Policies.ActiveUser))).Succeeded ? null : User.Identity?.Name;
     var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "unknown";
 }
 

--- a/src/WebApp/Platform/Services/ClaimsTransformation.cs
+++ b/src/WebApp/Platform/Services/ClaimsTransformation.cs
@@ -15,13 +15,13 @@ public class ClaimsTransformation : IClaimsTransformation
     {
         var userIsActive = (await _userManager.GetUserAsync(principal))!.Active;
 
-        if (principal.HasClaim(PolicyName.ActiveUser, userIsActive.ToString()))
+        if (principal.HasClaim(nameof(Policies.ActiveUser), userIsActive.ToString()))
             return principal;
 
         foreach (var identity in principal.Identities)
-            identity.TryRemoveClaim(identity.FindFirst(PolicyName.ActiveUser));
+            identity.TryRemoveClaim(identity.FindFirst(nameof(Policies.ActiveUser)));
 
-        (principal.Identity as ClaimsIdentity)!.AddClaim(new Claim(PolicyName.ActiveUser, userIsActive.ToString()));
+        (principal.Identity as ClaimsIdentity)!.AddClaim(new Claim(nameof(Policies.ActiveUser), userIsActive.ToString()));
 
         return principal;
     }

--- a/src/WebApp/Platform/Services/ClaimsTransformation.cs
+++ b/src/WebApp/Platform/Services/ClaimsTransformation.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+using Sbeap.AppServices.Permissions;
+using Sbeap.Domain.Identity;
+using System.Security.Claims;
+
+namespace Sbeap.WebApp.Platform.Services;
+
+public class ClaimsTransformation : IClaimsTransformation
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    public ClaimsTransformation(UserManager<ApplicationUser> userManager) => _userManager = userManager;
+
+    public async Task<ClaimsPrincipal> TransformAsync(ClaimsPrincipal principal)
+    {
+        var userIsActive = (await _userManager.GetUserAsync(principal))!.Active;
+
+        if (principal.HasClaim(PolicyName.ActiveUser, userIsActive.ToString()))
+            return principal;
+
+        foreach (var identity in principal.Identities)
+            identity.TryRemoveClaim(identity.FindFirst(PolicyName.ActiveUser));
+
+        (principal.Identity as ClaimsIdentity)!.AddClaim(new Claim(PolicyName.ActiveUser, userIsActive.ToString()));
+
+        return principal;
+    }
+}

--- a/src/WebApp/Program.cs
+++ b/src/WebApp/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.OpenApi.Models;
 using Mindscape.Raygun4Net.AspNetCore;
@@ -20,6 +21,7 @@ builder.Services.AddIdentityStores();
 
 // Configure Authentication.
 builder.Services.AddAuthenticationServices(builder.Configuration);
+builder.Services.AddTransient<IClaimsTransformation, ClaimsTransformation>();
 
 // Persist data protection keys.
 var keysFolder = Path.Combine(builder.Configuration["PersistedFilesBasePath"] ?? "", "DataProtectionKeys");

--- a/tests/AppServicesTests/Cases/Search.cs
+++ b/tests/AppServicesTests/Cases/Search.cs
@@ -3,8 +3,6 @@ using GaEpd.AppLibrary.Pagination;
 using Sbeap.AppServices.Cases;
 using Sbeap.AppServices.Cases.Dto;
 using Sbeap.AppServices.UserServices;
-using Sbeap.Domain.Entities.ActionItems;
-using Sbeap.Domain.Entities.ActionItemTypes;
 using Sbeap.Domain.Entities.Agencies;
 using Sbeap.Domain.Entities.Cases;
 using Sbeap.Domain.Entities.Customers;


### PR DESCRIPTION
This PR creates separate authorization policies for logged in users vs. active users. (A user can be marked inactive in the application, even while their SOG login remains valid.) This is accomplished by adding an additional claim to the logged in principle based on the `Active` value in the Users DB table.

An inactive user should be able to log in and view their own profile, but not access any other protected resources. Any Razor classes with a simple `[Authorize]` attribute are replaced with an attribute explicitly specifying an authorization policy, e.g., `[Authorize(Policy = PolicyName.ActiveUser)]`