### PR TITLE
Implement contact phone number editing

### DIFF
--- a/docs/Site map.md
+++ b/docs/Site map.md
@@ -15,7 +15,7 @@
 * `/Customers/Delete/{id}` (Delete Customer)
 * `/Customers/Restore/{id}` (Restore Customer)
 * `/Customers/Details/{id}/AddContact` (Add new Contact)
-* `/Customers/Details/{id}/EditContact/{contactId}` (Edit Contact)
+* `/Customers/EditContact/{contactId}` (Edit Contact)
 * `/Customers/Details/{id}/DeleteContact/{contactId}` (Delete Contact)
 
 ### Case Pages

--- a/docs/Site map.md
+++ b/docs/Site map.md
@@ -16,7 +16,7 @@
 * `/Customers/Restore/{id}` (Restore Customer)
 * `/Customers/Details/{id}/AddContact` (Add new Contact)
 * `/Customers/EditContact/{contactId}` (Edit Contact)
-* `/Customers/Details/{id}/DeleteContact/{contactId}` (Delete Contact)
+* `/Customers/DeleteContact/{contactId}` (Delete Contact)
 
 ### Case Pages
 

--- a/src/AppServices/Customers/Dto/ContactCreateDto.cs
+++ b/src/AppServices/Customers/Dto/ContactCreateDto.cs
@@ -1,4 +1,4 @@
-using Sbeap.Domain.ValueObjects;
+﻿using Sbeap.Domain.ValueObjects;
 using System.ComponentModel.DataAnnotations;
 
 namespace Sbeap.AppServices.Customers.Dto;
@@ -35,6 +35,6 @@ public record ContactCreateDto(Guid CustomerId)
         string.IsNullOrEmpty(Title) &&
         string.IsNullOrEmpty(Email) &&
         string.IsNullOrEmpty(Notes) &&
-        Address == IncompleteAddress.EmptyAddress &&
+        Address.IsEmpty &&
         PhoneNumber.IsIncomplete;
 }

--- a/src/AppServices/Customers/Dto/ContactCreateDto.cs
+++ b/src/AppServices/Customers/Dto/ContactCreateDto.cs
@@ -1,4 +1,4 @@
-﻿using Sbeap.Domain.ValueObjects;
+using Sbeap.Domain.ValueObjects;
 using System.ComponentModel.DataAnnotations;
 
 namespace Sbeap.AppServices.Customers.Dto;
@@ -26,9 +26,9 @@ public record ContactCreateDto(Guid CustomerId)
     public IncompleteAddress Address { get; init; } = new();
 
     [Display(Name = "Phone number")]
-    public PhoneNumber PhoneNumber { get; init; } = new();
+    public PhoneNumberCreate PhoneNumber { get; init; } = new();
 
-    public bool IsEmpty() =>
+    public bool IsEmpty =>
         string.IsNullOrEmpty(Honorific) &&
         string.IsNullOrEmpty(GivenName) &&
         string.IsNullOrEmpty(FamilyName) &&
@@ -36,5 +36,5 @@ public record ContactCreateDto(Guid CustomerId)
         string.IsNullOrEmpty(Email) &&
         string.IsNullOrEmpty(Notes) &&
         Address == IncompleteAddress.EmptyAddress &&
-        PhoneNumber == PhoneNumber.EmptyPhoneNumber;
+        PhoneNumber.IsIncomplete;
 }

--- a/src/AppServices/Customers/Dto/ContactUpdateDto.cs
+++ b/src/AppServices/Customers/Dto/ContactUpdateDto.cs
@@ -7,12 +7,14 @@ public record ContactUpdateDto
 {
     // Authorization handler assist properties
 
-    public bool IsDeleted { get; [UsedImplicitly] init; }
-    public bool CustomerIsDeleted { get; [UsedImplicitly] init; }
+    public bool IsDeleted { get; set; }
+    public bool CustomerIsDeleted { get; set; }
+    public Guid CustomerId { get; set; }
 
     // Entity update properties
 
     public Guid Id { get; [UsedImplicitly] init; }
+
     public string? Honorific { get; init; }
 
     [Display(Name = "First name")]
@@ -30,5 +32,9 @@ public record ContactUpdateDto
     public string? Email { get; init; }
 
     public string? Notes { get; init; }
+
     public IncompleteAddress Address { get; init; } = default!;
+
+    [UsedImplicitly]
+    public List<PhoneNumber> PhoneNumbers { get; } = new();
 }

--- a/src/AppServices/Customers/Dto/ContactViewDto.cs
+++ b/src/AppServices/Customers/Dto/ContactViewDto.cs
@@ -9,6 +9,7 @@ namespace Sbeap.AppServices.Customers.Dto;
 public record ContactViewDto
 {
     public Guid Id { get; init; }
+    public Guid CustomerId { get; set; }
 
     [UsedImplicitly]
     public string Honorific { get; init; } = string.Empty;

--- a/src/AppServices/Customers/Dto/PhoneNumberCreate.cs
+++ b/src/AppServices/Customers/Dto/PhoneNumberCreate.cs
@@ -1,0 +1,20 @@
+using Sbeap.Domain.ValueObjects;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Sbeap.AppServices.Customers.Dto;
+
+public record PhoneNumberCreate
+{
+    [StringLength(25)]
+    [DataType(DataType.PhoneNumber)]
+    [Display(Name = "Phone number")]
+    public string? Number { get; [UsedImplicitly] init; }
+
+    [Display(Name = "Phone type")]
+    public PhoneType? Type { get; [UsedImplicitly] init; }
+
+    [MemberNotNullWhen(false, nameof(Number))]
+    [MemberNotNullWhen(false, nameof(Type))]
+    public bool IsIncomplete => string.IsNullOrEmpty(Number) || Type == null;
+}

--- a/src/AppServices/Customers/ICustomerService.cs
+++ b/src/AppServices/Customers/ICustomerService.cs
@@ -26,6 +26,8 @@ public interface ICustomerService : IDisposable
     Task<ContactUpdateDto?> FindContactForUpdateAsync(Guid contactId, CancellationToken token = default);
     Task UpdateContactAsync(ContactUpdateDto resource, CancellationToken token = default);
     Task DeleteContactAsync(Guid contactId, CancellationToken token = default);
-    Task AddPhoneNumberAsync(Guid contactId, PhoneNumber resource, CancellationToken token = default);
-    Task DeletePhoneNumberAsync(Guid contactId, PhoneNumber resource, CancellationToken token = default);
+
+    // Contact phone numbers
+    Task<PhoneNumber> AddPhoneNumberAsync(Guid contactId, PhoneNumberCreate resource, CancellationToken token = default);
+    Task DeletePhoneNumberAsync(Guid contactId, int phoneNumberId, CancellationToken token = default);
 }

--- a/src/AppServices/Customers/Validators/ContactCreateValidator.cs
+++ b/src/AppServices/Customers/Validators/ContactCreateValidator.cs
@@ -15,5 +15,10 @@ public class ContactCreateValidator : AbstractValidator<ContactCreateDto>
                 !string.IsNullOrWhiteSpace(c.FamilyName) ||
                 !string.IsNullOrWhiteSpace(c.Title))
             .WithMessage("At least a name or title must be entered to create a contact.");
+
+        // Embedded phone number
+        RuleFor(e => e.PhoneNumber)
+            .SetValidator(new PhoneNumberCreateValidator())
+            .When(e => !e.PhoneNumber.IsIncomplete);
     }
 }

--- a/src/AppServices/Customers/Validators/CustomerCreateValidator.cs
+++ b/src/AppServices/Customers/Validators/CustomerCreateValidator.cs
@@ -21,6 +21,6 @@ public class CustomerCreateValidator : AbstractValidator<CustomerCreateDto>
         // Embedded Contact
         RuleFor(e => e.Contact)
             .SetValidator(new ContactCreateValidator())
-            .When(e => !e.Contact.IsEmpty());
+            .When(e => !e.Contact.IsEmpty);
     }
 }

--- a/src/AppServices/Customers/Validators/PhoneNumberCreateValidator.cs
+++ b/src/AppServices/Customers/Validators/PhoneNumberCreateValidator.cs
@@ -1,0 +1,16 @@
+﻿using FluentValidation;
+using Sbeap.AppServices.Customers.Dto;
+
+namespace Sbeap.AppServices.Customers.Validators;
+
+public class PhoneNumberCreateValidator : AbstractValidator<PhoneNumberCreate>
+{
+    public PhoneNumberCreateValidator()
+    {
+        RuleFor(e => e)
+            .Must(c => !string.IsNullOrWhiteSpace(c.Number))
+            .WithMessage("Phone number must be entered.")
+            .Must(c => c.Type != null)
+            .WithMessage("Phone number type must be selected.");
+    }
+}

--- a/src/Domain/Entities/Contacts/Contact.cs
+++ b/src/Domain/Entities/Contacts/Contact.cs
@@ -37,5 +37,5 @@ public class Contact : AuditableSoftDeleteEntity
 
     // Collections
 
-    public ICollection<PhoneNumber> PhoneNumbers { get; } = new List<PhoneNumber>();
+    public List<PhoneNumber> PhoneNumbers { get; } = new();
 }

--- a/src/Domain/Entities/Contacts/IContactRepository.cs
+++ b/src/Domain/Entities/Contacts/IContactRepository.cs
@@ -1,3 +1,8 @@
 ﻿namespace Sbeap.Domain.Entities.Contacts;
 
-public interface IContactRepository : IRepository<Contact, Guid> { }
+public interface IContactRepository : IRepository<Contact, Guid>
+{
+    // Should return the next available Phone Number ID if the repository requires it for adding new entities (local repository).
+    // Should return null if the repository creates a new ID on insert (Entity Framework).
+    public int GetNextPhoneNumberId();
+}

--- a/src/Domain/Entities/Customers/CustomerManager.cs
+++ b/src/Domain/Entities/Customers/CustomerManager.cs
@@ -1,10 +1,14 @@
 ﻿using Sbeap.Domain.Entities.Contacts;
+using Sbeap.Domain.ValueObjects;
 
 namespace Sbeap.Domain.Entities.Customers;
 
 /// <inheritdoc />
 public class CustomerManager : ICustomerManager
 {
+    private readonly IContactRepository _contactRepository;
+    public CustomerManager(IContactRepository contactRepository) => _contactRepository = contactRepository;
+
     public Customer Create(string name, string? createdById)
     {
         var item = new Customer(Guid.NewGuid()) { Name = name };
@@ -18,4 +22,12 @@ public class CustomerManager : ICustomerManager
         item.SetCreator(createdById);
         return item;
     }
+
+    public PhoneNumber CreatePhoneNumber(string number, PhoneType type) =>
+        new()
+        {
+            Id = _contactRepository.GetNextPhoneNumberId(),
+            Number = number,
+            Type = type,
+        };
 }

--- a/src/Domain/Entities/Customers/ICustomerManager.cs
+++ b/src/Domain/Entities/Customers/ICustomerManager.cs
@@ -1,4 +1,5 @@
 using Sbeap.Domain.Entities.Contacts;
+using Sbeap.Domain.ValueObjects;
 
 namespace Sbeap.Domain.Entities.Customers;
 
@@ -22,4 +23,12 @@ public interface ICustomerManager
     /// <param name="createdById">The ID of the user creating the entity.</param>
     /// <returns>The Contact that was created.</returns>
     Contact CreateContact(Customer customer, string? createdById);
+
+    /// <summary>
+    /// Creates a new <see cref="PhoneNumber"/>.
+    /// </summary>
+    /// <param name="number">The number.</param>
+    /// <param name="type">The <see cref="PhoneType"/> of the number.</param>
+    /// <returns>The Phone Number that was created.</returns>
+    PhoneNumber CreatePhoneNumber(string number, PhoneType type);
 }

--- a/src/Domain/ValueObjects/IncompleteAddress.cs
+++ b/src/Domain/ValueObjects/IncompleteAddress.cs
@@ -34,4 +34,5 @@ public record IncompleteAddress : ValueObject
         .ConcatWithSeparator(", ");
 
     public static IncompleteAddress EmptyAddress => new();
+    public bool IsEmpty => this == EmptyAddress;
 }

--- a/src/Domain/ValueObjects/PhoneNumber.cs
+++ b/src/Domain/ValueObjects/PhoneNumber.cs
@@ -7,6 +7,8 @@ namespace Sbeap.Domain.ValueObjects;
 [Owned]
 public record PhoneNumber : ValueObject
 {
+    public int Id { get; init; }
+
     [StringLength(25)]
     [DataType(DataType.PhoneNumber)]
     [Display(Name = "Phone number")]
@@ -21,18 +23,24 @@ public record PhoneNumber : ValueObject
         yield return Number ?? string.Empty;
         yield return Type ?? PhoneType.Unknown;
     }
-
-    public static PhoneNumber EmptyPhoneNumber => new();
 }
 
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PhoneType
 {
-    Work = 0,
-    [Display(Name = "Work Cell")] WorkCell = 1,
-    Fax = 2,
-    Personal = 3,
-    [Display(Name = "Personal Cell")] PersonalCell = 4,
-    Other = 5,
-    Unknown = 6,
+    [UsedImplicitly] Work = 0,
+
+    [UsedImplicitly, Display(Name = "Work Cell")]
+    WorkCell = 1,
+
+    [UsedImplicitly] Fax = 2,
+
+    [UsedImplicitly] Personal = 3,
+
+    [UsedImplicitly, Display(Name = "Personal Cell")]
+    PersonalCell = 4,
+
+    [UsedImplicitly] Other = 5,
+
+    [UsedImplicitly] Unknown = 6,
 }

--- a/src/EfRepository/Contexts/AppDbContext.cs
+++ b/src/EfRepository/Contexts/AppDbContext.cs
@@ -33,6 +33,7 @@ public class AppDbContext : IdentityDbContext<ApplicationUser>
         // See https://learn.microsoft.com/en-us/ef/core/querying/related-data/eager#model-configuration-for-auto-including-navigations
         builder.Entity<ApplicationUser>().Navigation(user => user.Office).AutoInclude();
         builder.Entity<Casework>().Navigation(casework => casework.Customer).AutoInclude();
+        builder.Entity<Contact>().Navigation(user => user.Customer).AutoInclude();
 
         // Let's save enums in the database as strings.
         // See https://stackoverflow.com/a/55260541/212978

--- a/src/EfRepository/Contexts/SeedDevData/DbSeedDataHelpers.cs
+++ b/src/EfRepository/Contexts/SeedDevData/DbSeedDataHelpers.cs
@@ -46,10 +46,10 @@ public static class DbSeedDataHelpers
         context.SaveChanges();
     }
 
-    private static void SeedContactData(AppDbContext context)
+    internal static void SeedContactData(AppDbContext context)
     {
         if (context.Contacts.Any()) return;
-        context.Contacts.AddRange(ContactData.GetContacts);
+        context.Contacts.AddRange(ContactData.GetContacts(false));
         context.SaveChanges();
     }
 

--- a/src/EfRepository/Repositories/ContactRepository.cs
+++ b/src/EfRepository/Repositories/ContactRepository.cs
@@ -6,4 +6,7 @@ namespace Sbeap.EfRepository.Repositories;
 public sealed class ContactRepository : BaseRepository<Contact, Guid>, IContactRepository
 {
     public ContactRepository(AppDbContext context) : base(context) { }
+
+    // EF will set the ID automatically.
+    public int GetNextPhoneNumberId() => 0;
 }

--- a/src/LocalRepository/Repositories/LocalContactRepository.cs
+++ b/src/LocalRepository/Repositories/LocalContactRepository.cs
@@ -5,5 +5,10 @@ namespace Sbeap.LocalRepository.Repositories;
 
 public sealed class LocalContactRepository : BaseRepository<Contact, Guid>, IContactRepository
 {
-    public LocalContactRepository() : base(ContactData.GetContacts) { }
+    public LocalContactRepository() : base(ContactData.GetContacts(true)) { }
+
+    // Local repository requires ID to be manually set.
+    public int GetNextPhoneNumberId() => Items
+        .SelectMany(e => e.PhoneNumbers)
+        .Max(p => p.Id) + 1;
 }

--- a/src/TestData/Constants/TextData.cs
+++ b/src/TestData/Constants/TextData.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 
 namespace Sbeap.TestData.Constants;
 
@@ -17,6 +17,10 @@ public static class TextData
     public const string AdditionalPhoneNumber = "770-555-1212";
     public const string? NullString = null;
     public const string EmptyString = "";
+
+    // GUIDs
+
+    public static readonly Guid TestGuid = new("99999999-0000-0000-0000-000000000009");
 
     // Words and phrases generated from [Cupcake Ipsum](https://cupcakeipsum.com/).
     public const string Word = "Cupcake";

--- a/src/TestData/Constants/TextData.cs
+++ b/src/TestData/Constants/TextData.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Sbeap.TestData.Constants;
 
@@ -14,6 +14,7 @@ public static class TextData
     public const string ValidUrl = "https://example.net";
     public const string ValidPhoneNumber = "404-555-1212";
     public const string AlternatePhoneNumber = "678-555-1212";
+    public const string AdditionalPhoneNumber = "770-555-1212";
     public const string? NullString = null;
     public const string EmptyString = "";
 

--- a/src/TestData/Constants/ValueObjectData.cs
+++ b/src/TestData/Constants/ValueObjectData.cs
@@ -4,21 +4,24 @@ namespace Sbeap.TestData.Constants;
 
 public static class ValueObjectData
 {
-    public static PhoneNumber SamplePhoneNumber => new()
+    public static PhoneNumber ValidPhoneNumber(int id) => new()
     {
+        Id = id,
         Number = TextData.ValidPhoneNumber,
         Type = PhoneType.Work,
     };
 
-    public static PhoneNumber AlternatePhoneNumber => new()
+    public static PhoneNumber AlternatePhoneNumber(int id) => new()
     {
+        Id = id,
         Number = TextData.AlternatePhoneNumber,
         Type = PhoneType.WorkCell,
     };
 
-    public static PhoneNumber UnknownPhoneNumber => new()
+    public static PhoneNumber AdditionalPhoneNumber(int id) => new()
     {
-        Number = TextData.ValidPhoneNumber,
+        Id = id,
+        Number = TextData.AdditionalPhoneNumber,
         Type = PhoneType.Unknown,
     };
 

--- a/src/TestData/ContactData.cs
+++ b/src/TestData/ContactData.cs
@@ -7,7 +7,7 @@ namespace Sbeap.TestData;
 
 internal static class ContactData
 {
-    private static IEnumerable<Contact> ContactSeedItems => new List<Contact>
+    private static IEnumerable<Contact> ContactSeedItems(int seedPhoneIds) => new List<Contact>
     {
         new(new Guid("41000000-0000-0000-0000-000000000001"),
             CustomerData.GetCustomers.ElementAt(0))
@@ -23,9 +23,9 @@ internal static class ContactData
             Address = ValueObjectData.CompleteAddress,
             PhoneNumbers =
             {
-                ValueObjectData.SamplePhoneNumber,
-                ValueObjectData.AlternatePhoneNumber,
-                ValueObjectData.UnknownPhoneNumber,
+                ValueObjectData.ValidPhoneNumber(seedPhoneIds * 91),
+                ValueObjectData.AlternatePhoneNumber(seedPhoneIds * 92),
+                ValueObjectData.AdditionalPhoneNumber(seedPhoneIds * 93),
             },
         },
         new(new Guid("41000000-0000-0000-0000-000000000002"),
@@ -53,7 +53,7 @@ internal static class ContactData
             Email = TextData.ValidEmail,
             Notes = TextData.Paragraph,
             Address = ValueObjectData.IncompleteAddress,
-            PhoneNumbers = { ValueObjectData.SamplePhoneNumber },
+            PhoneNumbers = { ValueObjectData.ValidPhoneNumber(seedPhoneIds * 94) },
         },
         new(new Guid("41000000-0000-0000-0000-000000000004"),
             CustomerData.GetCustomers.ElementAt(2))
@@ -67,21 +67,22 @@ internal static class ContactData
             Email = TextData.ValidEmail,
             Notes = TextData.Paragraph,
             Address = ValueObjectData.IncompleteAddress,
-            PhoneNumbers = { ValueObjectData.SamplePhoneNumber },
+            PhoneNumbers = { ValueObjectData.ValidPhoneNumber(seedPhoneIds * 95) },
         },
     };
 
     private static IEnumerable<Contact>? _contacts;
 
-    public static IEnumerable<Contact> GetContacts
+    public static IEnumerable<Contact> GetContacts(bool seedPhoneIds)
     {
-        get
-        {
-            if (_contacts is not null) return _contacts;
-            _contacts = ContactSeedItems.ToList();
-            _contacts.ElementAt(2).SetDeleted("00000000-0000-0000-0000-000000000001");
-            return _contacts;
-        }
+        if (_contacts is not null) return _contacts;
+
+        // When `seedPhoneIds` is true, Phone Number IDs will be seeded.
+        // When `seedPhoneIds` is false, all Phone Number IDs will be set to zero so that EF can auto-create them.
+        _contacts = ContactSeedItems(seedPhoneIds ? 1 : 0).ToList();
+
+        _contacts.ElementAt(2).SetDeleted("00000000-0000-0000-0000-000000000001");
+        return _contacts;
     }
 
     public static void ClearData() => _contacts = null;

--- a/src/WebApp/Pages/Account/ExternalLogin.cshtml.cs
+++ b/src/WebApp/Pages/Account/ExternalLogin.cshtml.cs
@@ -66,18 +66,18 @@ public class ExternalLoginModel : PageModel
     private async Task<IActionResult> SignInAsLocalUser()
     {
         _logger.LogInformation(
-            "Local user signin attempted with settings {LocalUserIsAuthenticated}, {LocalUserIsStaff}, and {LocalUserIsAdmin}",
+            "Local user signin attempted with settings {LocalUserIsAuthenticated}, {LocalUserIsAdmin}, and {LocalUserIsStaff}",
             ApplicationSettings.DevSettings.LocalUserIsAuthenticated,
-            ApplicationSettings.DevSettings.LocalUserIsStaff,
-            ApplicationSettings.DevSettings.LocalUserIsAdmin);
+            ApplicationSettings.DevSettings.LocalUserIsAdmin,
+            ApplicationSettings.DevSettings.LocalUserIsStaff);
         if (!ApplicationSettings.DevSettings.LocalUserIsAuthenticated) return Forbid();
 
         StaffSearchDto search;
 
-        if (ApplicationSettings.DevSettings.LocalUserIsStaff)
-            search = new StaffSearchDto(SortBy.NameAsc, "General", null, null, null, null);
-        else if (ApplicationSettings.DevSettings.LocalUserIsAdmin)
+        if (ApplicationSettings.DevSettings.LocalUserIsAdmin)
             search = new StaffSearchDto(SortBy.NameAsc, "Admin", null, null, null, null);
+        else if (ApplicationSettings.DevSettings.LocalUserIsStaff)
+            search = new StaffSearchDto(SortBy.NameAsc, "General", null, null, null, null);
         else
             search = new StaffSearchDto(SortBy.NameAsc, "Limited", null, null, null, null);
 

--- a/src/WebApp/Pages/Customers/Add.cshtml
+++ b/src/WebApp/Pages/Customers/Add.cshtml
@@ -83,10 +83,11 @@
 
         <div class="row mt-2">
             <h2>Contact <small class="text-muted">(optional)</small></h2>
-            <p class="form-text">At least a name or title must be entered in order to create a contact.</p>
+            <p class="form-text text-info">Additional contacts can be added later.</p>
 
             <div class="col-md-6">
                 <h3 class="h5 d-none d-md-block">Personal Info</h3>
+            <p class="form-text"><span class="text-danger">*</span> At least a name or title must be entered in order to create a contact.</p>
                 <div class="input-group mb-3">
                     @Html.EditorFor(e => e.Item.Contact.Honorific, EditorTemplate.Input)
                     @Html.EditorFor(e => e.Item.Contact.GivenName, EditorTemplate.Input)
@@ -98,6 +99,7 @@
                 <div class="mb-3">
                     @Html.EditorFor(e => e.Item.Contact.Email, EditorTemplate.Input)
                 </div>
+                <div class="form-text text-info mb-1">Additional phone numbers can be added later.</div>
                 <div class="input-group mb-3">
                     @Html.EditorFor(e => e.Item.Contact.PhoneNumber.Number, EditorTemplate.Input)
                     @Html.EditorFor(e => e.Item.Contact.PhoneNumber.Type, EditorTemplate.SelectOptional, new { Items = phoneTypesSelectList })

--- a/src/WebApp/Pages/Customers/AddContact.cshtml
+++ b/src/WebApp/Pages/Customers/AddContact.cshtml
@@ -29,7 +29,7 @@
         <div asp-validation-summary="All" class="alert alert-danger" role="alert"></div>
 
         <div class="row mt-2">
-            <p class="form-text">At least a name or title must be entered in order to create a contact.</p>
+            <p class="form-text"><span class="text-danger">*</span> At least a name or title must be entered in order to create a contact.</p>
 
             <div class="col-md-6">
                 <h3 class="h5 d-none d-md-block">Personal Info</h3>
@@ -44,6 +44,7 @@
                 <div class="mb-3">
                     @Html.EditorFor(e => e.NewContact.Email, EditorTemplate.Input)
                 </div>
+                <div class="form-text text-info mb-1">Additional phone numbers can be added later.</div>
                 <div class="input-group mb-3">
                     @Html.EditorFor(e => e.NewContact.PhoneNumber.Number, EditorTemplate.Input)
                     @Html.EditorFor(e => e.NewContact.PhoneNumber.Type, EditorTemplate.SelectOptional, new { Items = phoneTypesSelectList })

--- a/src/WebApp/Pages/Customers/AddContact.cshtml.cs
+++ b/src/WebApp/Pages/Customers/AddContact.cshtml.cs
@@ -74,7 +74,7 @@ public class AddContactModel : PageModel
 
         HighlightId = await _service.AddContactAsync(NewContact);
         TempData.SetDisplayMessage(DisplayMessage.AlertContext.Success, "New Contact successfully added.");
-        return RedirectToPage("Details", new { id });
+        return RedirectToPage("Details", null, new { id }, "contacts");
     }
 
     private async Task<bool> UserCanManageDeletionsAsync() =>

--- a/src/WebApp/Pages/Customers/DeleteContact.cshtml
+++ b/src/WebApp/Pages/Customers/DeleteContact.cshtml
@@ -1,4 +1,4 @@
-﻿@page "~/Customers/Details/{id:guid?}/DeleteContact/{contactId:guid?}"
+﻿@page "~/Customers/DeleteContact/{id:guid?}"
 @using Sbeap.WebApp.Pages.Shared.DisplayTemplates
 @model DeleteContactModel
 

--- a/src/WebApp/Pages/Customers/Details.cshtml
+++ b/src/WebApp/Pages/Customers/Details.cshtml
@@ -190,7 +190,7 @@ else
                                         <a asp-page="EditContact" asp-route-id="@item.Id" class="btn btn-sm btn-outline-primary">Edit</a>
                                         @if (Model.UserCan[CustomerOperation.ManageDeletions])
                                         {
-                                            <a asp-page="DeleteContact" asp-route-id="@Model.Item.Id" asp-route-contactId="@item.Id" class="btn btn-sm btn-outline-danger ms-1">Delete</a>
+                                            <a asp-page="DeleteContact" asp-route-id="@item.Id" class="btn btn-sm btn-outline-danger ms-1">Delete</a>
                                         }
                                     </div>
                                 }

--- a/src/WebApp/Pages/Customers/Details.cshtml
+++ b/src/WebApp/Pages/Customers/Details.cshtml
@@ -1,4 +1,4 @@
-@page "{id:guid?}"
+﻿@page "{id:guid?}"
 @using Sbeap.AppServices.Customers.Permissions
 @using Sbeap.WebApp.Pages.Shared.DisplayTemplates
 @using Sbeap.WebApp.Pages.Shared.EditorTemplates
@@ -187,7 +187,7 @@ else
                                 @if (Model.UserCan[CustomerOperation.Edit])
                                 {
                                     <div class="col-auto d-print-none ms-2">
-                                        <a asp-page="EditContact" asp-route-id="@Model.Item.Id" asp-route-contactId="@item.Id" class="btn btn-sm btn-outline-primary">Edit</a>
+                                        <a asp-page="EditContact" asp-route-id="@item.Id" class="btn btn-sm btn-outline-primary">Edit</a>
                                         @if (Model.UserCan[CustomerOperation.ManageDeletions])
                                         {
                                             <a asp-page="DeleteContact" asp-route-id="@Model.Item.Id" asp-route-contactId="@item.Id" class="btn btn-sm btn-outline-danger ms-1">Delete</a>

--- a/src/WebApp/Pages/Customers/Details.cshtml
+++ b/src/WebApp/Pages/Customers/Details.cshtml
@@ -1,4 +1,4 @@
-﻿@page "{id:guid?}"
+@page "{id:guid?}"
 @using Sbeap.AppServices.Customers.Permissions
 @using Sbeap.WebApp.Pages.Shared.DisplayTemplates
 @using Sbeap.WebApp.Pages.Shared.EditorTemplates
@@ -171,8 +171,18 @@ else
                         <div class="container-full">
                             <div class="row justify-content-between align-items-start g-0 my-1">
                                 <div class="col">
-                                    <h3 class="h5 card-title">@Html.DisplayFor(m => item.Name)</h3>
-                                    <h4 class="h5 card-subtitle text-muted">@Html.DisplayFor(m => item.Title)</h4>
+                                    @if (string.IsNullOrEmpty(item.Name))
+                                    {
+                                        <h3 class="h5 card-title">@Html.DisplayFor(m => item.Title)</h3>
+                                    }
+                                    else
+                                    {
+                                        <h3 class="h5 card-title">@Html.DisplayFor(m => item.Name)</h3>
+                                        @if (!string.IsNullOrEmpty(item.Title))
+                                        {
+                                            <h4 class="h5 card-subtitle text-muted no-anchor">@Html.DisplayFor(m => item.Title)</h4>
+                                        }
+                                    }
                                 </div>
                                 @if (Model.UserCan[CustomerOperation.Edit])
                                 {

--- a/src/WebApp/Pages/Customers/EditContact.cshtml
+++ b/src/WebApp/Pages/Customers/EditContact.cshtml
@@ -1,7 +1,9 @@
-﻿@page "~/Customers/Details/{id:guid?}/EditContact/{contactId:guid?}"
+﻿@page "~/Customers/EditContact/{id:guid?}"
+@using GaEpd.AppLibrary.Enums
 @using Sbeap.Domain.ValueObjects
 @using Sbeap.WebApp.Pages.Shared.DisplayTemplates
 @using Sbeap.WebApp.Pages.Shared.EditorTemplates
+@using Sbeap.WebApp.Platform.Constants
 @model EditContactModel
 @{
     ViewData["Title"] = "Edit Contact";
@@ -9,13 +11,11 @@
     var phoneTypesSelectList = Html.GetEnumSelectList<PhoneType>().ToArray();
 }
 
-<h1>@ViewData["Title"]</h1>
-
-<h2 class="h3">For Customer</h2>
+<h1>@ViewData["Title"] for Customer</h1>
 
 <div class="container mt-3">
     <dl class="row">
-        <dt class="col-md-4 col-lg-3">@Html.DisplayNameFor(m => m.CustomerView.Name)</dt>
+        <dt class="col-md-4 col-lg-3">Customer Name</dt>
         <dd class="col-md-8 col-lg-9">@Html.DisplayFor(m => m.CustomerView.Name, DisplayTemplate.StringOrNotEntered)</dd>
         <dt class="col-md-4 col-lg-3">@Html.DisplayNameFor(m => m.CustomerView.Description)</dt>
         <dd class="col-md-8 col-lg-9">@Html.DisplayFor(m => m.CustomerView.Description, DisplayTemplate.TruncateText)</dd>
@@ -24,15 +24,18 @@
     </dl>
 </div>
 
-<div class="p-3 border rounded-3 bg-light">
-    <form method="post" asp-fragment="@Model.ContactUpdate.Id">
-        <div asp-validation-summary="All" class="alert alert-danger" role="alert"></div>
+<form method="post">
+    <div class="p-3 border rounded-3 bg-light mb-3">
+        @if (Model.Handler == EditContactModel.Handlers.EditContact)
+        {
+            <div asp-validation-summary="All" class="alert alert-danger" role="alert"></div>
+        }
 
         <div class="row mt-2">
-            <p class="form-text">At least a name or title must be entered in order to create a contact.</p>
+            <p class="form-text"><span class="text-danger">*</span> At least a name or title must be included in order to save a contact.</p>
 
             <div class="col-md-6">
-                <h3 class="h5 d-none d-md-block">Personal Info</h3>
+                <h3 class="h5">Personal Info</h3>
                 <div class="input-group mb-3">
                     @Html.EditorFor(e => e.ContactUpdate.Honorific, EditorTemplate.Input)
                     @Html.EditorFor(e => e.ContactUpdate.GivenName, EditorTemplate.Input)
@@ -50,7 +53,7 @@
             </div>
 
             <div class="col-md-6">
-                <h3>Mailing Address <small class="text-muted me-1">(optional)</small></h3>
+                <h3 class="h5">Mailing Address <small class="text-muted me-1">(optional)</small></h3>
 
                 <div class="mb-3">
                     @Html.EditorFor(e => e.ContactUpdate.Address.Street, EditorTemplate.Input)
@@ -69,13 +72,62 @@
         </div>
 
         <div class="mt-3 mb-1">
-            <button id="SubmitButton" type="submit" class="btn btn-primary col-6 col-sm-4 col-lg-3 me-2">Save Changes</button>
+            <button asp-page-handler="SaveContact" id="SubmitButton" type="submit" class="btn btn-primary col-6 col-sm-4 col-lg-3 me-2">Save Changes</button>
             <a asp-page="Details" asp-route-id="@Model.CustomerView.Id" asp-fragment="contacts" class="btn btn-outline-secondary">Cancel</a>
         </div>
         <div class="text-danger mt-3">* denotes a required field</div>
-        <input asp-for="ContactUpdate.Id" type="hidden">
-    </form>
-</div>
+    </div>
+
+    <div class="p-3 border rounded-3 bg-light" id="phone-numbers">
+        <h3 class="h5 mb-3">Phone Numbers</h3>
+        @if (Model.PhoneNumberMessage != null)
+        {
+            <div class="alert @Model.PhoneNumberMessage.AlertClass alert-dismissible fade show" role="alert">
+                @Model.PhoneNumberMessage.Message
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+        }
+
+        @if (Model.ContactUpdate.PhoneNumbers.Count != 0 && !Model.ContactUpdate.PhoneNumbers.All(e => string.IsNullOrWhiteSpace(e.Number)))
+        {
+            foreach (var item in Model.ContactUpdate.PhoneNumbers)
+            {
+                <div class="mb-3">
+                    <button asp-page-handler="DeletePhoneNumber" asp-fragment="phone-numbers"
+                            name="phoneNumberId" value="@item.Id"
+                            class="btn btn-sm btn-outline-danger lh-1 align-bottom px-1 py-1"
+                            title="Delete phone number">
+                        🗙 <span class="visually-hidden">Delete</span>
+                    </button>
+                    @item.Number
+                    @if (item.Type != null)
+                    {
+                        <em>(@item.Type.GetDisplayName())</em>
+                    }
+                </div>
+            }
+        }
+
+        @if (Model.Handler == EditContactModel.Handlers.PhoneNumber)
+        {
+            <div asp-validation-summary="All" class="alert alert-danger" role="alert"></div>
+        }
+        <div class="mt-3 mb-1">
+            <h4 class="h6">Add a Phone Number</h4>
+
+            <div class="row col-md-6 mb-3">
+                <div class=" input-group">
+                    <input asp-for="NewPhoneNumber.Number" class="form-control" aria-label="Phone number" placeholder="Phone number" />
+                    <select asp-for="NewPhoneNumber.Type" asp-items="phoneTypesSelectList" class="form-select">
+                        <option value="">@TextConstants.SelectTextRequiredType</option>
+                    </select>
+                    <button asp-page-handler="AddPhoneNumber" asp-fragment="phone-numbers" name="AddPhoneNumberButton" type="submit" class="btn btn-sm btn-primary">Add</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <input asp-for="ContactUpdate.Id" type="hidden">
+</form>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/src/WebApp/Pages/Customers/EditContact.cshtml.cs
+++ b/src/WebApp/Pages/Customers/EditContact.cshtml.cs
@@ -19,21 +19,27 @@ public class EditContactModel : PageModel
     // Constructor
     private readonly ICustomerService _service;
     private readonly IValidator<ContactUpdateDto> _validator;
+    private readonly IValidator<PhoneNumberCreate> _phoneValidator;
     private readonly IAuthorizationService _authorization;
 
     public EditContactModel(
         ICustomerService service,
         IValidator<ContactUpdateDto> validator,
+        IValidator<PhoneNumberCreate> phoneValidator,
         IAuthorizationService authorization)
     {
         _service = service;
         _validator = validator;
+        _phoneValidator = phoneValidator;
         _authorization = authorization;
     }
 
     // Properties
     [BindProperty]
     public ContactUpdateDto ContactUpdate { get; set; } = default!;
+
+    [BindProperty]
+    public PhoneNumberCreate NewPhoneNumber { get; set; } = default!;
 
     [TempData]
     public Guid HighlightId { get; set; }
@@ -44,18 +50,29 @@ public class EditContactModel : PageModel
     // Select lists
     public SelectList StatesSelectList => new(Data.States);
 
-    // Methods
-    public async Task<IActionResult> OnGetAsync(Guid? id, Guid? contactId)
+    // Messaging
+    public Handlers Handler { get; private set; } = Handlers.None;
+    public DisplayMessage? PhoneNumberMessage { get; private set; }
+
+    public enum Handlers
     {
-        if (id is null || contactId is null) return RedirectToPage("../Index");
+        None,
+        EditContact,
+        PhoneNumber,
+    }
 
-        var customer = await _service.FindBasicInfoAsync(id.Value);
-        if (customer is null) return NotFound();
-        CustomerView = customer;
+    // Methods
+    public async Task<IActionResult> OnGetAsync(Guid? id)
+    {
+        if (id is null) return RedirectToPage("Index");
 
-        var contact = await _service.FindContactForUpdateAsync(contactId.Value);
+        var contact = await _service.FindContactForUpdateAsync(id.Value);
         if (contact is null) return NotFound();
         ContactUpdate = contact;
+
+        var customer = await _service.FindBasicInfoAsync(contact.CustomerId);
+        if (customer is null) return NotFound();
+        CustomerView = customer;
 
         foreach (var operation in CustomerOperation.AllOperations) await SetPermissionAsync(operation);
 
@@ -63,21 +80,18 @@ public class EditContactModel : PageModel
         if (!UserCan[CustomerOperation.ManageDeletions]) return NotFound();
 
         TempData.SetDisplayMessage(DisplayMessage.AlertContext.Info, "Cannot edit a deleted customer or contact.");
-        return RedirectToPage("Details", new { id });
+        return RedirectToPage("Details", new { id = ContactUpdate.CustomerId });
     }
 
-    public async Task<IActionResult> OnPostAsync(Guid? id)
+    public async Task<IActionResult> OnPostSaveContactAsync(Guid? id)
     {
-        if (id is null) return RedirectToPage("../Index");
+        if (id is null || id != ContactUpdate.Id) return RedirectToPage("Index");
+        if (!await RefreshExistingData(id.Value)) return BadRequest();
 
         foreach (var operation in CustomerOperation.AllOperations) await SetPermissionAsync(operation);
         if (!UserCan[CustomerOperation.Edit]) return Forbid();
 
-        var customer = await _service.FindBasicInfoAsync(id.Value);
-        if (customer is null) return BadRequest();
-
-        CustomerView = customer;
-        if (CustomerView.IsDeleted) return BadRequest();
+        Handler = Handlers.EditContact;
 
         await _validator.ApplyValidationAsync(ContactUpdate, ModelState);
         if (!ModelState.IsValid) return Page();
@@ -86,9 +100,63 @@ public class EditContactModel : PageModel
 
         HighlightId = ContactUpdate.Id;
         TempData.SetDisplayMessage(DisplayMessage.AlertContext.Success, "Contact successfully updated.");
-        return RedirectToPage("Details", new { id });
+        return RedirectToPage("Details", null, new { id = ContactUpdate.CustomerId }, id.ToString());
+    }
+
+    public async Task<IActionResult> OnPostAddPhoneNumberAsync(Guid? id)
+    {
+        if (id is null || id != ContactUpdate.Id) return RedirectToPage("Index");
+        if (!await RefreshExistingData(id.Value)) return BadRequest();
+
+        Handler = Handlers.PhoneNumber;
+
+        await _phoneValidator.ApplyValidationAsync(NewPhoneNumber, ModelState);
+        if (ContactUpdate.PhoneNumbers.Exists(p => p.Number == NewPhoneNumber.Number))
+            ModelState.AddModelError(nameof(NewPhoneNumber.Number), "Phone number already exists.");
+
+        if (!ModelState.IsValid) return Page();
+
+        var result = await _service.AddPhoneNumberAsync(id.Value, NewPhoneNumber);
+        ContactUpdate.PhoneNumbers.Add(result);
+        ModelState.Remove("NewPhoneNumber.Number");
+        ModelState.Remove("NewPhoneNumber.Type");
+        NewPhoneNumber = new PhoneNumberCreate();
+
+        PhoneNumberMessage = new DisplayMessage(DisplayMessage.AlertContext.Success, "New phone number added.");
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostDeletePhoneNumberAsync(Guid? id, int? phoneNumberId)
+    {
+        if (id is null || id != ContactUpdate.Id || phoneNumberId is null) return RedirectToPage("Index");
+        if (!await RefreshExistingData(id.Value)) return BadRequest();
+
+        Handler = Handlers.PhoneNumber;
+
+        await _service.DeletePhoneNumberAsync(id.Value, phoneNumberId.Value);
+        ContactUpdate.PhoneNumbers.RemoveAll(p => p.Id == phoneNumberId);
+
+        PhoneNumberMessage = new DisplayMessage(DisplayMessage.AlertContext.Success, "Phone number deleted.");
+        return Page();
     }
 
     private async Task SetPermissionAsync(IAuthorizationRequirement operation) =>
         UserCan[operation] = (await _authorization.AuthorizeAsync(User, ContactUpdate, operation)).Succeeded;
+
+    private async Task<bool> RefreshExistingData(Guid id)
+    {
+        var originalContact = await _service.FindContactForUpdateAsync(id);
+        if (originalContact is null) return false;
+        ContactUpdate.IsDeleted = originalContact.IsDeleted;
+        ContactUpdate.CustomerIsDeleted = originalContact.CustomerIsDeleted;
+        ContactUpdate.CustomerId = originalContact.CustomerId;
+        ContactUpdate.PhoneNumbers.Clear();
+        ContactUpdate.PhoneNumbers.AddRange(originalContact.PhoneNumbers);
+
+        var customer = await _service.FindBasicInfoAsync(originalContact.CustomerId);
+        if (customer is null) return false;
+
+        CustomerView = customer;
+        return true;
+    }
 }

--- a/src/WebApp/Pages/Index.cshtml
+++ b/src/WebApp/Pages/Index.cshtml
@@ -35,7 +35,7 @@ else
                     <tr>
                         <th scope="col" class="ps-3">Date Opened</th>
                         <th scope="col">Customer</th>
-                        <th scope="col">Description</th>
+                        <th scope="col">Case Description</th>
                         <th scope="col" class="pe-3">
                             <span class="visually-hidden">Actions</span>
                         </th>

--- a/src/WebApp/Pages/Shared/_Layout.cshtml
+++ b/src/WebApp/Pages/Shared/_Layout.cshtml
@@ -60,8 +60,8 @@
 @if (!ViewData.ContainsKey("NoAnchors") || (bool)(ViewData["NoAnchors"] ?? false) != true)
 {
     <script src="~/lib/anchor-js/anchor.min.js"></script>
+    <script src="~/js/anchorInit.js"></script>
 }
-<script src="~/js/site.js"></script>
 @await RenderSectionAsync("Scripts", false)
 </body>
 </html>

--- a/src/WebApp/Platform/Constants/TextConstants.cs
+++ b/src/WebApp/Platform/Constants/TextConstants.cs
@@ -6,5 +6,6 @@ internal static class TextConstants
     public const string SelectNotDeleted = "Not Deleted";
     public const string SelectTextAny = "(any)";
     public const string SelectTextEmpty = "";
-    public const string SelectTextRequired = "[select …]";
+    public const string SelectTextRequired = "[Select …]";
+    public const string SelectTextRequiredType = "[Select Type …]";
 }

--- a/src/WebApp/wwwroot/js/anchorInit.js
+++ b/src/WebApp/wwwroot/js/anchorInit.js
@@ -1,0 +1,9 @@
+﻿// Write your JavaScript code.
+
+const anchors = new AnchorJS();
+// DOMContentLoaded was tested to be the best place to call anchors.add()
+window.addEventListener('DOMContentLoaded', function () {
+    anchors.options.placement = "left";
+    // Add anchors to h2, h3, h4, h5, and h6 elements, but exclude any with the "no-anchor" class.
+    anchors.add('h2:not(.no-anchor), h3:not(.no-anchor), h4:not(.no-anchor), h5:not(.no-anchor), h6:not(.no-anchor)');
+})

--- a/src/WebApp/wwwroot/js/site.js
+++ b/src/WebApp/wwwroot/js/site.js
@@ -1,9 +1,0 @@
-﻿// Write your JavaScript code.
-
-const anchors = new AnchorJS();
-// DOMContentLoaded was tested to be the best place to call anchors.add()
-window.addEventListener('DOMContentLoaded', function (event) {
-    anchors.options.placement = "left";
-    // default to adding h2, h3, h4, h5, and h6
-    anchors.add();
-})

--- a/tests/AppServicesTests/AutoMapper/ContactMapping.cs
+++ b/tests/AppServicesTests/AutoMapper/ContactMapping.cs
@@ -30,4 +30,34 @@ public class ContactMapping
             result.Title.Should().Be(item.Title);
         }
     }
+
+    [Test]
+    public void ContactUpdateMappingWorks()
+    {
+        var customer = new Customer(TextData.TestGuid);
+        customer.SetDeleted(null);
+
+        var item = new Contact(Guid.NewGuid(), customer)
+        {
+            Honorific = TextData.Word,
+            GivenName = TextData.AnotherWord,
+            FamilyName = TextData.ThirdWord,
+            Title = TextData.EmojiWord,
+        };
+        item.SetDeleted(null);
+
+        var result = AppServicesTestsSetup.Mapper!.Map<ContactUpdateDto>(item);
+
+        using (new AssertionScope())
+        {
+            result.Id.Should().Be(item.Id);
+            result.Honorific.Should().Be(item.Honorific);
+            result.GivenName.Should().Be(item.GivenName);
+            result.FamilyName.Should().Be(item.FamilyName);
+            result.Title.Should().Be(item.Title);
+            result.IsDeleted.Should().BeTrue();
+            result.CustomerIsDeleted.Should().BeTrue();
+            result.CustomerId.Should().Be(TextData.TestGuid);
+        }
+    }
 }

--- a/tests/EfRepositoryTests/Contacts/GetNextPhoneNumberId.cs
+++ b/tests/EfRepositoryTests/Contacts/GetNextPhoneNumberId.cs
@@ -1,0 +1,20 @@
+using Sbeap.Domain.Entities.Contacts;
+
+namespace EfRepositoryTests.Contacts;
+
+public class GetNextPhoneNumberId
+{
+    private IContactRepository _repository = default!;
+
+    [SetUp]
+    public void SetUp() => _repository = RepositoryHelper.CreateRepositoryHelper().GetContactRepository();
+
+    [TearDown]
+    public void TearDown() => _repository.Dispose();
+
+    [Test]
+    public void GivenEF_ReturnsZero()
+    {
+        _repository.GetNextPhoneNumberId().Should().Be(0);
+    }
+}

--- a/tests/EfRepositoryTests/RepositoryHelper.cs
+++ b/tests/EfRepositoryTests/RepositoryHelper.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Sbeap.Domain.Entities.ActionItemTypes;
 using Sbeap.Domain.Entities.Agencies;
 using Sbeap.Domain.Entities.Cases;
+using Sbeap.Domain.Entities.Contacts;
 using Sbeap.Domain.Entities.Customers;
 using Sbeap.Domain.Entities.Offices;
 using Sbeap.EfRepository.Contexts;
@@ -137,7 +138,7 @@ public sealed class RepositoryHelper : IDisposable
     }
 
     /// <summary>
-    /// Seeds data for the Action Item Type entity and returns an instance of ActionItemTypeRepository.
+    /// Seeds data and returns an instance of ActionItemTypeRepository.
     /// </summary>
     /// <returns>An <see cref="ActionItemTypeRepository"/>.</returns>
     public IActionItemTypeRepository GetActionItemTypeRepository()
@@ -149,7 +150,7 @@ public sealed class RepositoryHelper : IDisposable
     }
 
     /// <summary>
-    /// Seeds data for the Agency entity and returns an instance of AgencyRepository.
+    /// Seeds data and returns an instance of AgencyRepository.
     /// </summary>
     /// <returns>An <see cref="AgencyRepository"/>.</returns>
     public IAgencyRepository GetAgencyRepository()
@@ -161,7 +162,7 @@ public sealed class RepositoryHelper : IDisposable
     }
 
     /// <summary>
-    /// Seeds data for the Casework entity and returns an instance of CaseworkRepository.
+    /// Seeds data and returns an instance of CaseworkRepository.
     /// </summary>
     /// <returns>An <see cref="CaseworkRepository"/>.</returns>
     public ICaseworkRepository GetCaseworkRepository()
@@ -173,7 +174,7 @@ public sealed class RepositoryHelper : IDisposable
     }
 
     /// <summary>
-    /// Seeds data for the Customer entity and returns an instance of CustomerRepository.
+    /// Seeds data and returns an instance of CustomerRepository.
     /// </summary>
     /// <returns>An <see cref="CustomerRepository"/>.</returns>
     public ICustomerRepository GetCustomerRepository()
@@ -185,7 +186,19 @@ public sealed class RepositoryHelper : IDisposable
     }
 
     /// <summary>
-    /// Seeds data for the Office entity and returns an instance of OfficeRepository.
+    /// Seeds data and returns an instance of ContactRepository.
+    /// </summary>
+    /// <returns>An <see cref="ContactRepository"/>.</returns>
+    public IContactRepository GetContactRepository()
+    {
+        ClearAllStaticData();
+        DbSeedDataHelpers.SeedContactData(_context);
+        Context = new AppDbContext(_options);
+        return new ContactRepository(Context);
+    }
+
+    /// <summary>
+    /// Seeds data and returns an instance of OfficeRepository.
     /// </summary>
     /// <returns>An <see cref="OfficeRepository"/>.</returns>
     public IOfficeRepository GetOfficeRepository()

--- a/tests/LocalRepositoryTests/Contacts/GetNextPhoneNumberId.cs
+++ b/tests/LocalRepositoryTests/Contacts/GetNextPhoneNumberId.cs
@@ -1,0 +1,24 @@
+using Sbeap.LocalRepository.Repositories;
+
+namespace LocalRepositoryTests.Contacts;
+
+public class GetNextPhoneNumberId
+{
+    private LocalContactRepository _repository = default!;
+
+    [SetUp]
+    public void SetUp() => _repository = new LocalContactRepository();
+
+    [TearDown]
+    public void TearDown() => _repository.Dispose();
+
+
+    [Test]
+    public void GivenLocalRepository_ReturnsNextIdNumber()
+    {
+        var maxId = _repository.Items
+            .SelectMany(e => e.PhoneNumbers)
+            .Max(e => e.Id);
+        _repository.GetNextPhoneNumberId().Should().Be(maxId + 1);
+    }
+}


### PR DESCRIPTION
This took a while to get working right, and it feels really over-engineered! Let me know if anything doesn't make sense.

The first couple of commits are just fixes for existing bugs.

The commit about explicitly managing phone number IDs addresses two issues:

1. I originally handled phone numbers as a simple list with no IDs -- a contact can have multiple phone numbers, but no number takes precedence over the others, and EF handles that situation seamlessly. But that ended up making it difficult and tedious, for example, to delete a number from the list. 

    EF was already generating an ID behind the scenes anyway for its own convenience; I just made it available to the rest of the program to use. See [this article](https://learn.microsoft.com/en-us/ef/core/modeling/owned-entities#collections-of-owned-types) if you want to learn more about how that worked.

5. Creating IDs for new data is easy when the ID is a `guid` since in-memory data and entity framework both work the same way if you explicitly generate an ID. But when the ID is an `int`, it's trickier. When using in-memory data, you have to add the ID yourself, but when using Entity Framework, you have to leave the ID empty (actually zero), so EF can generate the next sequential ID from the database. Otherwise you get `IDENTITY_INSERT` errors. That's why there's a new `GetNextPhoneNumberId` method in the Contact repository.

The remaining commits are for implementing the front end.